### PR TITLE
test: shared/lib 유틸 함수 단위 테스트 추가

### DIFF
--- a/src/shared/lib/__tests__/asyncStorage.test.ts
+++ b/src/shared/lib/__tests__/asyncStorage.test.ts
@@ -1,0 +1,85 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Toast from 'react-native-toast-message';
+import { getData } from '../getData';
+import { setData } from '../setData';
+import { removeData } from '../removeData';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  show: jest.fn(),
+}));
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockToast = Toast as jest.Mocked<typeof Toast>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getData', () => {
+  it('저장된 값을 반환한다', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('stored-value');
+
+    const result = await getData('myKey');
+
+    expect(mockAsyncStorage.getItem).toHaveBeenCalledWith('myKey');
+    expect(result).toBe('stored-value');
+  });
+
+  it('값이 없으면 null을 반환한다', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue(null);
+
+    const result = await getData('missingKey');
+
+    expect(result).toBeNull();
+  });
+
+  it('AsyncStorage가 throw하면 Toast 에러를 표시하고 에러를 전파한다', async () => {
+    const storageError = new Error('Storage read failed');
+    mockAsyncStorage.getItem.mockRejectedValue(storageError);
+
+    await expect(getData('failKey')).rejects.toThrow('Storage read failed');
+    expect(mockToast.show).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});
+
+describe('setData', () => {
+  it('주어진 key-value를 AsyncStorage에 저장한다', async () => {
+    mockAsyncStorage.setItem.mockResolvedValue();
+
+    await setData('accessToken', 'abc123');
+
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('accessToken', 'abc123');
+  });
+
+  it('AsyncStorage가 throw하면 Toast 에러를 표시하고 에러를 전파한다', async () => {
+    const storageError = new Error('Storage write failed');
+    mockAsyncStorage.setItem.mockRejectedValue(storageError);
+
+    await expect(setData('failKey', 'value')).rejects.toThrow('Storage write failed');
+    expect(mockToast.show).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});
+
+describe('removeData', () => {
+  it('주어진 key를 AsyncStorage에서 삭제한다', async () => {
+    mockAsyncStorage.removeItem.mockResolvedValue();
+
+    await removeData('accessToken');
+
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('accessToken');
+  });
+
+  it('AsyncStorage가 throw하면 Toast 에러를 표시하고 에러를 전파한다', async () => {
+    const storageError = new Error('Storage delete failed');
+    mockAsyncStorage.removeItem.mockRejectedValue(storageError);
+
+    await expect(removeData('failKey')).rejects.toThrow('Storage delete failed');
+    expect(mockToast.show).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});

--- a/src/shared/lib/__tests__/errorHandler.test.ts
+++ b/src/shared/lib/__tests__/errorHandler.test.ts
@@ -1,0 +1,110 @@
+import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { getErrorMessage } from '../errorHandler';
+
+const makeAxiosError = (message: string, responseData?: unknown, status?: number): AxiosError => {
+  const config = { headers: {} } as InternalAxiosRequestConfig;
+  const response =
+    responseData !== undefined || status !== undefined
+      ? ({
+          data: responseData,
+          status: status ?? 400,
+          statusText: 'Bad Request',
+          headers: {},
+          config,
+        } as AxiosResponse)
+      : undefined;
+
+  const error = new AxiosError(message, 'ERR_BAD_REQUEST', config, null, response);
+  return error;
+};
+
+describe('getErrorMessage', () => {
+  describe('AxiosError — response data에 message 필드가 있을 때', () => {
+    it('message에 "default message [xxx]" 패턴이 있으면 마지막 [...] 내용을 반환한다', () => {
+      const error = makeAxiosError(
+        'validation failed',
+        { message: 'Validation failed: default message [비밀번호를 입력해주세요]' },
+        400
+      );
+      expect(getErrorMessage(error)).toBe('비밀번호를 입력해주세요');
+    });
+
+    it('"default message [...]" 패턴이 여러 개면 마지막 것을 반환한다', () => {
+      const error = makeAxiosError(
+        'validation failed',
+        {
+          message:
+            'Validation failed: default message [첫 번째 오류], default message [두 번째 오류]',
+        },
+        400
+      );
+      expect(getErrorMessage(error)).toBe('두 번째 오류');
+    });
+
+    it('message에 regex 패턴이 없으면 message 원문을 반환한다', () => {
+      const error = makeAxiosError(
+        'request failed',
+        { message: '사용자를 찾을 수 없습니다.' },
+        404
+      );
+      expect(getErrorMessage(error)).toBe('사용자를 찾을 수 없습니다.');
+    });
+
+    it('message가 빈 문자열이면 빈 문자열을 반환한다', () => {
+      const error = makeAxiosError('request failed', { message: '' }, 400);
+      expect(getErrorMessage(error)).toBe('');
+    });
+  });
+
+  describe('AxiosError — response data에 message 필드가 없을 때', () => {
+    it('status 코드가 있으면 "요청이 실패했습니다. (status)" 형태로 반환한다', () => {
+      const error = makeAxiosError('server error', null, 500);
+      expect(getErrorMessage(error)).toBe('요청이 실패했습니다. (500)');
+    });
+
+    it('status 403도 동일한 형태로 반환한다', () => {
+      const error = makeAxiosError('forbidden', undefined, 403);
+      expect(getErrorMessage(error)).toBe('요청이 실패했습니다. (403)');
+    });
+
+    it('response 자체가 없으면 error.message를 반환한다 (Error 폴백)', () => {
+      const config = { headers: {} } as InternalAxiosRequestConfig;
+      const error = new AxiosError('Network Error', 'ERR_NETWORK', config, null, undefined);
+      expect(getErrorMessage(error)).toBe('Network Error');
+    });
+  });
+
+  describe('일반 Error 인스턴스', () => {
+    it('error.message를 그대로 반환한다', () => {
+      expect(getErrorMessage(new Error('일반 오류 메시지'))).toBe('일반 오류 메시지');
+    });
+
+    it('빈 message인 Error도 그대로 반환한다', () => {
+      expect(getErrorMessage(new Error(''))).toBe('');
+    });
+  });
+
+  describe('문자열 error', () => {
+    it('문자열을 그대로 반환한다', () => {
+      expect(getErrorMessage('직접 전달된 에러 문자열')).toBe('직접 전달된 에러 문자열');
+    });
+  });
+
+  describe('그 외 타입', () => {
+    it('null이면 알 수 없는 오류 메시지를 반환한다', () => {
+      expect(getErrorMessage(null)).toBe('알 수 없는 오류가 발생했습니다.');
+    });
+
+    it('undefined이면 알 수 없는 오류 메시지를 반환한다', () => {
+      expect(getErrorMessage(undefined)).toBe('알 수 없는 오류가 발생했습니다.');
+    });
+
+    it('숫자이면 알 수 없는 오류 메시지를 반환한다', () => {
+      expect(getErrorMessage(404)).toBe('알 수 없는 오류가 발생했습니다.');
+    });
+
+    it('객체이면 알 수 없는 오류 메시지를 반환한다', () => {
+      expect(getErrorMessage({ code: 'ERR' })).toBe('알 수 없는 오류가 발생했습니다.');
+    });
+  });
+});

--- a/src/shared/lib/__tests__/getCurrentUserId.test.ts
+++ b/src/shared/lib/__tests__/getCurrentUserId.test.ts
@@ -1,0 +1,46 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { getCurrentUserId, clearCurrentUserId } from '../getCurrentUserId';
+
+let mockService: any;
+
+// 팩토리 안에서 서비스를 생성하고 외부 변수에 할당 — clearAllMocks 이후에도 참조 유지
+jest.mock('@/entity/auth/lib/userSessionService', () => ({
+  createUserSessionService: jest.fn(() => {
+    mockService = {
+      getCurrentUserId: jest.fn(),
+      clearSession: jest.fn(),
+      getCurrentSession: jest.fn(),
+      isSessionValid: jest.fn(),
+    };
+    return mockService;
+  }),
+}));
+
+describe('getCurrentUserId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('userSessionService.getCurrentUserId 결과를 반환한다', async () => {
+    mockService.getCurrentUserId.mockResolvedValue(42);
+
+    const result = await getCurrentUserId();
+
+    expect(mockService.getCurrentUserId).toHaveBeenCalledTimes(1);
+    expect(result).toBe(42);
+  });
+
+  it('세션이 없으면 에러를 전파한다', async () => {
+    mockService.getCurrentUserId.mockRejectedValue(new Error('Authentication required'));
+
+    await expect(getCurrentUserId()).rejects.toThrow('Authentication required');
+  });
+});
+
+describe('clearCurrentUserId', () => {
+  it('userSessionService.clearSession을 호출한다', () => {
+    clearCurrentUserId();
+
+    expect(mockService.clearSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/lib/__tests__/userUtils.test.ts
+++ b/src/shared/lib/__tests__/userUtils.test.ts
@@ -1,0 +1,134 @@
+import { extractOtherUserInfo, checkIsMyPost, ensureMessagesArray } from '../userUtils';
+import { getData } from '../getData';
+import type { ChatMessageResponse } from '~/entity/chat/model/chatTypes';
+
+jest.mock('../getData', () => ({
+  getData: jest.fn(),
+}));
+
+const mockGetData = getData as jest.MockedFunction<typeof getData>;
+
+const makeMessage = (overrides: Partial<ChatMessageResponse>): ChatMessageResponse => ({
+  id: 1,
+  content: '안녕하세요',
+  isMine: false,
+  senderId: 99,
+  senderNickname: '상대방닉네임',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  messageType: 'TEXT',
+  ...overrides,
+});
+
+describe('extractOtherUserInfo', () => {
+  it('isMine이 false인 첫 메시지에서 nickname과 id를 반환한다', () => {
+    const messages: ChatMessageResponse[] = [
+      makeMessage({ isMine: true, senderId: 1, senderNickname: '나' }),
+      makeMessage({ isMine: false, senderId: 42, senderNickname: '광산주민' }),
+    ];
+
+    const result = extractOtherUserInfo(messages);
+
+    expect(result.nickname).toBe('광산주민');
+    expect(result.id).toBe(42);
+  });
+
+  it('isMine이 false인 메시지가 없으면 nickname을 "상대방"으로 반환하고 id는 undefined이다', () => {
+    const messages: ChatMessageResponse[] = [
+      makeMessage({ isMine: true, senderId: 1, senderNickname: '나' }),
+    ];
+
+    const result = extractOtherUserInfo(messages);
+
+    expect(result.nickname).toBe('상대방');
+    expect(result.id).toBeUndefined();
+  });
+
+  it('빈 배열이면 nickname을 "상대방", id는 undefined로 반환한다', () => {
+    const result = extractOtherUserInfo([]);
+
+    expect(result.nickname).toBe('상대방');
+    expect(result.id).toBeUndefined();
+  });
+});
+
+describe('checkIsMyPost', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('저장된 memberId와 authorId가 같으면 true를 반환한다', async () => {
+    mockGetData.mockResolvedValue('7');
+
+    const result = await checkIsMyPost(7);
+
+    expect(mockGetData).toHaveBeenCalledWith('memberId');
+    expect(result).toBe(true);
+  });
+
+  it('authorId가 string 타입이어도 숫자 비교로 true를 반환한다', async () => {
+    mockGetData.mockResolvedValue('7');
+
+    const result = await checkIsMyPost('7');
+
+    expect(result).toBe(true);
+  });
+
+  it('저장된 memberId와 authorId가 다르면 false를 반환한다', async () => {
+    mockGetData.mockResolvedValue('5');
+
+    const result = await checkIsMyPost(7);
+
+    expect(result).toBe(false);
+  });
+
+  it('memberId가 0이면 false를 반환한다', async () => {
+    mockGetData.mockResolvedValue('0');
+
+    const result = await checkIsMyPost(0);
+
+    expect(result).toBe(false);
+  });
+
+  it('memberId가 null이면 false를 반환한다', async () => {
+    mockGetData.mockResolvedValue(null);
+
+    const result = await checkIsMyPost(7);
+
+    expect(result).toBe(false);
+  });
+
+  it('getData가 throw하면 false를 반환한다 (에러 전파 안 함)', async () => {
+    mockGetData.mockRejectedValue(new Error('Storage error'));
+
+    const result = await checkIsMyPost(7);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('ensureMessagesArray', () => {
+  it('배열이면 그대로 반환한다', () => {
+    const messages = [makeMessage({})];
+    expect(ensureMessagesArray(messages)).toBe(messages);
+  });
+
+  it('빈 배열이면 빈 배열을 반환한다', () => {
+    expect(ensureMessagesArray([])).toEqual([]);
+  });
+
+  it('null이면 빈 배열을 반환한다', () => {
+    expect(ensureMessagesArray(null)).toEqual([]);
+  });
+
+  it('undefined이면 빈 배열을 반환한다', () => {
+    expect(ensureMessagesArray(undefined)).toEqual([]);
+  });
+
+  it('객체이면 빈 배열을 반환한다', () => {
+    expect(ensureMessagesArray({ 0: makeMessage({}) })).toEqual([]);
+  });
+
+  it('문자열이면 빈 배열을 반환한다', () => {
+    expect(ensureMessagesArray('message')).toEqual([]);
+  });
+});

--- a/src/shared/lib/__tests__/userUtils.test.ts
+++ b/src/shared/lib/__tests__/userUtils.test.ts
@@ -9,13 +9,15 @@ jest.mock('../getData', () => ({
 const mockGetData = getData as jest.MockedFunction<typeof getData>;
 
 const makeMessage = (overrides: Partial<ChatMessageResponse>): ChatMessageResponse => ({
-  id: 1,
+  messageId: 1,
+  roomId: 'room-1',
   content: '안녕하세요',
   isMine: false,
   senderId: 99,
   senderNickname: '상대방닉네임',
   createdAt: '2026-01-01T00:00:00.000Z',
   messageType: 'TEXT',
+  checked: false,
   ...overrides,
 });
 


### PR DESCRIPTION
## 요약

- `errorHandler.ts` — Spring 스타일 `default message [...]` regex 파싱 로직을 포함한 모든 분기 검증 (AxiosError / 일반 Error / string / unknown)
- `userUtils.ts` — `extractOtherUserInfo`, `checkIsMyPost`, `ensureMessagesArray` 각 엣지케이스 (상대방 없음, memberId=0, getData throw 시 false 반환 등) 검증
- `getData` / `setData` / `removeData` — AsyncStorage 성공/실패 분기 및 실패 시 Toast 표시 여부 검증
- `getCurrentUserId` — 모듈 로드 시 싱글턴으로 생성되는 `userSessionService` 특성에 맞게 팩토리 내부 할당 패턴으로 mock 설계

## 테스트 계획

- [ ] `npm test -- --testPathPattern="shared/lib/__tests__"` 실행 시 39개 테스트 전부 PASS 확인
- [ ] `getErrorMessage`에 `default message [xxx]` 패턴이 여러 개일 때 마지막 값만 반환하는지 확인
- [ ] `checkIsMyPost`에서 `getData`가 throw할 때 에러 전파 없이 `false` 반환하는지 확인
- [ ] `getData` / `setData` / `removeData` 실패 시 Toast `type: 'error'`가 호출되는지 확인
- [ ] `npm run lint` 실행 시 우리 파일에서 추가된 경고 없는지 확인
