### PR TITLE
test: shared·widget·view 레이어 단위 테스트 추가

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'jest-expo',
   setupFiles: ['./jest.setup.js'],
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|@sentry/react-native|react-native-toast-message|react-native-keychain|react-native-modal|react-native-reanimated|msw|@mswjs|until-async)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|nativewind|@sentry/react-native|react-native-toast-message|react-native-keychain|react-native-modal|react-native-reanimated|msw|@mswjs|until-async|immer)',
   ],
   moduleNameMapper: {
     '^react-native-reanimated$': '<rootDir>/__mocks__/react-native-reanimated.js',

--- a/src/shared/api/__tests__/getPosts.test.ts
+++ b/src/shared/api/__tests__/getPosts.test.ts
@@ -1,0 +1,111 @@
+import { getPosts } from '../getPosts';
+import { instance } from '~/shared/lib/axios';
+import Toast from 'react-native-toast-message';
+
+jest.mock('~/shared/lib/axios', () => ({
+  instance: { get: jest.fn() },
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockGet = instance.get as jest.Mock;
+
+const makeRawPost = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: '테스트 게시글',
+  content: '내용',
+  gwangsan: '광산구',
+  type: 'OBJECT',
+  mode: 'GIVER',
+  images: ['https://example.com/img.jpg'],
+  isCompletable: true,
+  isCompleted: false,
+  ...overrides,
+});
+
+describe('getPosts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('성공 케이스', () => {
+    it('응답 데이터를 PostType 형태로 변환해 반환한다', async () => {
+      mockGet.mockResolvedValue({ data: [makeRawPost()] });
+
+      const result = await getPosts();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: 1,
+        title: '테스트 게시글',
+        imageUrls: ['https://example.com/img.jpg'],
+        isCompletable: true,
+        isCompleted: false,
+      });
+    });
+
+    it('images가 없으면 imageUrls를 빈 배열로 설정한다', async () => {
+      mockGet.mockResolvedValue({ data: [makeRawPost({ images: undefined })] });
+
+      const result = await getPosts();
+
+      expect(result[0].imageUrls).toEqual([]);
+    });
+
+    it('isCompletable이 없으면 false로 기본값을 설정한다', async () => {
+      mockGet.mockResolvedValue({ data: [makeRawPost({ isCompletable: undefined })] });
+
+      const result = await getPosts();
+
+      expect(result[0].isCompletable).toBe(false);
+    });
+
+    it('type이 있으면 쿼리스트링에 포함한다', async () => {
+      mockGet.mockResolvedValue({ data: [] });
+
+      await getPosts('OBJECT');
+
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('type=OBJECT'));
+    });
+
+    it('mode가 있으면 쿼리스트링에 포함한다', async () => {
+      mockGet.mockResolvedValue({ data: [] });
+
+      await getPosts(undefined, 'GIVER');
+
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('mode=GIVER'));
+    });
+
+    it('params 없이 호출하면 빈 쿼리스트링으로 요청한다', async () => {
+      mockGet.mockResolvedValue({ data: [] });
+
+      await getPosts();
+
+      expect(mockGet).toHaveBeenCalledWith('/post?');
+    });
+  });
+
+  describe('에러 케이스', () => {
+    it('API 실패 시 Toast 에러를 표시하고 빈 배열을 반환한다', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockGet.mockRejectedValue(new Error('Network error'));
+
+      const result = await getPosts();
+
+      expect(result).toEqual([]);
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', text1: '게시물 불러오기 실패' })
+      );
+    });
+
+    it('Error 인스턴스가 아닌 예외는 Toast를 표시하지 않고 빈 배열을 반환한다', async () => {
+      mockGet.mockRejectedValue('string error');
+
+      const result = await getPosts();
+
+      expect(result).toEqual([]);
+      expect(Toast.show).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared/api/__tests__/uploadImage.test.ts
+++ b/src/shared/api/__tests__/uploadImage.test.ts
@@ -1,0 +1,67 @@
+import { uploadImage } from '../uploadImage';
+import { instance } from '~/shared/lib/axios';
+
+jest.mock('~/shared/lib/axios', () => ({
+  instance: { post: jest.fn() },
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+jest.mock('expo-file-system', () => ({
+  getInfoAsync: jest.fn(),
+}));
+
+const mockPost = instance.post as jest.Mock;
+
+describe('uploadImage', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('성공 시 서버 응답 데이터를 반환한다', async () => {
+    const mockResponse = { imageId: 1, imageUrl: 'https://cdn.example.com/img.jpg' };
+    mockPost.mockResolvedValue({ data: mockResponse });
+
+    const result = await uploadImage('file:///local/path/photo.jpg');
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('multipart/form-data Content-Type으로 POST 요청한다', async () => {
+    mockPost.mockResolvedValue({ data: { imageId: 1, imageUrl: '' } });
+
+    await uploadImage('file:///local/path/photo.jpg');
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/image',
+      expect.any(Object),
+      expect.objectContaining({
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+    );
+  });
+
+  it('URI에서 파일명을 추출해 FormData에 추가한다', async () => {
+    mockPost.mockResolvedValue({ data: { imageId: 1, imageUrl: '' } });
+
+    await uploadImage('file:///local/path/photo.png');
+
+    const formData = mockPost.mock.calls[0][1] as FormData;
+    expect(formData).toBeDefined();
+  });
+
+  it('확장자가 없는 URI는 jpeg를 기본 타입으로 사용한다', async () => {
+    mockPost.mockResolvedValue({ data: { imageId: 1, imageUrl: '' } });
+
+    await uploadImage('file:///local/path/photo');
+
+    expect(mockPost).toHaveBeenCalled();
+  });
+
+  it('API 실패 시 에러를 그대로 던진다', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockPost.mockRejectedValue(new Error('Upload failed'));
+
+    await expect(uploadImage('file:///local/path/photo.jpg')).rejects.toThrow('Upload failed');
+  });
+});

--- a/src/shared/api/__tests__/uploadImage.test.ts
+++ b/src/shared/api/__tests__/uploadImage.test.ts
@@ -1,6 +1,8 @@
 import { uploadImage } from '../uploadImage';
 import { instance } from '~/shared/lib/axios';
 
+import * as FileSystem from 'expo-file-system';
+
 jest.mock('~/shared/lib/axios', () => ({
   instance: { post: jest.fn() },
 }));
@@ -14,6 +16,7 @@ jest.mock('expo-file-system', () => ({
 }));
 
 const mockPost = instance.post as jest.Mock;
+const mockGetInfoAsync = FileSystem.getInfoAsync as jest.Mock;
 
 describe('uploadImage', () => {
   beforeEach(() => jest.clearAllMocks());
@@ -63,5 +66,50 @@ describe('uploadImage', () => {
     mockPost.mockRejectedValue(new Error('Upload failed'));
 
     await expect(uploadImage('file:///local/path/photo.jpg')).rejects.toThrow('Upload failed');
+  });
+
+  describe('Android 플랫폼', () => {
+    const platform = require('react-native').Platform;
+
+    beforeEach(() => {
+      platform.OS = 'android';
+    });
+
+    afterEach(() => {
+      platform.OS = 'ios';
+    });
+
+    // 확장자가 없는 URI: 파일명이 '.'으로 끝나면 fileType='' (falsy) → Android 분기 진입
+    it('Android에서 fileType이 빈 문자열인 URI + 파일 존재 시 getInfoAsync를 호출한다', async () => {
+      mockGetInfoAsync.mockResolvedValue({ exists: true });
+      mockPost.mockResolvedValue({ data: { imageId: 1, imageUrl: '' } });
+
+      await uploadImage('file:///local/path/photo.');
+
+      expect(mockGetInfoAsync).toHaveBeenCalledWith('file:///local/path/photo.');
+    });
+
+    it('Android에서 fileType이 빈 문자열인 URI + 파일 미존재 시 jpeg 기본 타입으로 요청한다', async () => {
+      mockGetInfoAsync.mockResolvedValue({ exists: false });
+      mockPost.mockResolvedValue({ data: { imageId: 1, imageUrl: '' } });
+
+      await uploadImage('file:///local/path/photo.');
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/image',
+        expect.any(Object),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'multipart/form-data' },
+        })
+      );
+    });
+
+    it('Android에서 확장자 있는 URI는 getInfoAsync를 호출하지 않는다', async () => {
+      mockPost.mockResolvedValue({ data: { imageId: 1, imageUrl: '' } });
+
+      await uploadImage('file:///local/path/photo.jpg');
+
+      expect(mockGetInfoAsync).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/shared/lib/__tests__/useChatEntry.test.ts
+++ b/src/shared/lib/__tests__/useChatEntry.test.ts
@@ -1,0 +1,114 @@
+import { act, waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useChatEntry } from '../useChatEntry';
+import { findChatRoom, createChatRoom } from '@/entity/chat';
+import Toast from 'react-native-toast-message';
+
+jest.mock('@/entity/chat', () => ({
+  findChatRoom: jest.fn(),
+  createChatRoom: jest.fn(),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockFindChatRoom = findChatRoom as jest.Mock;
+const mockCreateChatRoom = createChatRoom as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('useChatEntry', () => {
+  it('초기 상태: isLoading이 false이다', () => {
+    const { result } = renderHookWithProviders(() => useChatEntry());
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('findChatRoom 성공 시 해당 채팅방으로 이동한다', async () => {
+    mockFindChatRoom.mockResolvedValue({ roomId: 'room-42' });
+
+    const { result } = renderHookWithProviders(() => useChatEntry());
+
+    await act(async () => {
+      await result.current.navigateToChat(1);
+    });
+
+    expect(mockFindChatRoom).toHaveBeenCalledWith(1);
+    expect(mockPush).toHaveBeenCalledWith('/chatting/room-42');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('findChatRoom 실패(방 없음) 시 createChatRoom을 호출한다', async () => {
+    mockFindChatRoom.mockRejectedValue(new Error('해당하는 채팅방을 찾을 수 없습니다.'));
+    mockCreateChatRoom.mockResolvedValue({ roomId: 'new-room-1' });
+
+    const { result } = renderHookWithProviders(() => useChatEntry());
+
+    await act(async () => {
+      await result.current.navigateToChat(2);
+    });
+
+    expect(mockCreateChatRoom).toHaveBeenCalledWith(2);
+    expect(mockPush).toHaveBeenCalledWith('/chatting/new-room-1');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('findChatRoom 실패(방 없음) + createChatRoom 실패 시 create error Toast를 표시한다', async () => {
+    mockFindChatRoom.mockRejectedValue(new Error('해당하는 채팅방을 찾을 수 없습니다.'));
+    mockCreateChatRoom.mockRejectedValue(new Error('채팅방 생성 실패'));
+
+    const { result } = renderHookWithProviders(() => useChatEntry());
+
+    await act(async () => {
+      await result.current.navigateToChat(3);
+    });
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'create error', text1: '채팅방 생성 실패' })
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('findChatRoom 기타 에러 시 error Toast를 표시한다', async () => {
+    mockFindChatRoom.mockRejectedValue(new Error('서버 오류'));
+
+    const { result } = renderHookWithProviders(() => useChatEntry());
+
+    await act(async () => {
+      await result.current.navigateToChat(4);
+    });
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', text1: '서버 오류' })
+    );
+    expect(mockCreateChatRoom).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('navigateToChat 호출 중 isLoading이 true가 된다', async () => {
+    let resolveFind!: (value: any) => void;
+    mockFindChatRoom.mockReturnValue(new Promise((res) => (resolveFind = res)));
+
+    const { result } = renderHookWithProviders(() => useChatEntry());
+
+    act(() => {
+      result.current.navigateToChat(5);
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    await act(async () => {
+      resolveFind({ roomId: 'room-5' });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/shared/model/__tests__/useGetPosts.test.ts
+++ b/src/shared/model/__tests__/useGetPosts.test.ts
@@ -1,0 +1,56 @@
+import { waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useGetPosts } from '../useGetPosts';
+import { getPosts } from '../../api/getPosts';
+
+jest.mock('../../api/getPosts', () => ({
+  getPosts: jest.fn(),
+}));
+
+const mockGetPosts = getPosts as jest.Mock;
+
+const makePosts = () => [
+  { id: 1, title: '게시글', imageUrls: [], isCompletable: false, isCompleted: false },
+];
+
+describe('useGetPosts', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('getPosts를 호출하고 데이터를 반환한다', async () => {
+    mockGetPosts.mockResolvedValue(makePosts());
+
+    const { result } = renderHookWithProviders(() => useGetPosts());
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(makePosts());
+  });
+
+  it('queryKey에 mode와 type을 포함한다', async () => {
+    mockGetPosts.mockResolvedValue([]);
+
+    const { queryClient } = renderHookWithProviders(() => useGetPosts('GIVER', 'OBJECT'));
+
+    await waitFor(() =>
+      expect(queryClient.getQueryState(['posts', 'GIVER', 'OBJECT'])).toBeDefined()
+    );
+  });
+
+  it('params 없이 호출하면 queryKey가 [posts, undefined, undefined]이다', async () => {
+    mockGetPosts.mockResolvedValue([]);
+
+    const { queryClient } = renderHookWithProviders(() => useGetPosts());
+
+    await waitFor(() =>
+      expect(queryClient.getQueryState(['posts', undefined, undefined])).toBeDefined()
+    );
+  });
+
+  it('getPosts에 type과 mode 순서대로 전달한다', async () => {
+    mockGetPosts.mockResolvedValue([]);
+
+    renderHookWithProviders(() => useGetPosts('GIVER', 'OBJECT'));
+
+    await waitFor(() => expect(mockGetPosts).toHaveBeenCalledWith('OBJECT', 'GIVER'));
+  });
+});

--- a/src/shared/model/__tests__/useUploadImage.test.ts
+++ b/src/shared/model/__tests__/useUploadImage.test.ts
@@ -1,0 +1,82 @@
+import { act, waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useUploadImage } from '../useUploadImage';
+import { uploadImage } from '../../api/uploadImage';
+import Toast from 'react-native-toast-message';
+
+jest.mock('../../api/uploadImage', () => ({
+  uploadImage: jest.fn(),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockUploadImage = uploadImage as jest.Mock;
+
+describe('useUploadImage', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('mutationFn으로 uploadImage를 호출한다', async () => {
+    const mockResult = { imageId: 1, imageUrl: 'https://cdn.example.com/img.jpg' };
+    mockUploadImage.mockResolvedValue(mockResult);
+
+    const { result } = renderHookWithProviders(() => useUploadImage());
+
+    await act(async () => {
+      result.current.mutate('file:///local/photo.jpg');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUploadImage).toHaveBeenCalledWith('file:///local/photo.jpg');
+  });
+
+  it('업로드 성공 시 성공 Toast를 표시한다', async () => {
+    mockUploadImage.mockResolvedValue({ imageId: 1, imageUrl: '' });
+
+    const { result } = renderHookWithProviders(() => useUploadImage());
+
+    await act(async () => {
+      result.current.mutate('file:///local/photo.jpg');
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'success', text1: '이미지 업로드 성공' })
+    );
+  });
+
+  it('업로드 실패 시 에러 Toast를 표시한다', async () => {
+    mockUploadImage.mockRejectedValue(new Error('업로드 오류'));
+
+    const { result } = renderHookWithProviders(() => useUploadImage());
+
+    await act(async () => {
+      result.current.mutate('file:///local/photo.jpg');
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', text1: '이미지 업로드 실패', text2: '업로드 오류' })
+    );
+  });
+
+  it('에러 메시지가 없으면 기본 메시지를 표시한다', async () => {
+    mockUploadImage.mockRejectedValue(new Error(''));
+
+    const { result } = renderHookWithProviders(() => useUploadImage());
+
+    await act(async () => {
+      result.current.mutate('file:///local/photo.jpg');
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        text2: '이미지 업로드 중 오류가 발생했습니다.',
+      })
+    );
+  });
+});

--- a/src/view/cancelTrade/__tests__/cancelTrade.test.ts
+++ b/src/view/cancelTrade/__tests__/cancelTrade.test.ts
@@ -1,0 +1,58 @@
+import { waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { getReview } from '../api/getReview';
+import { useGetReview } from '../model/useGetReview';
+
+jest.mock('../api/getReview', () => ({
+  getReview: jest.fn(),
+}));
+
+const mockGetReview = getReview as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getReview', () => {
+  it('getReview를 호출하면 응답 data를 반환한다', async () => {
+    const reviewData = { review_id: 1, title: '좋아요', content: '만족', light: 80, imageUrls: [] };
+    mockGetReview.mockResolvedValue(reviewData);
+
+    const result = await getReview('1');
+
+    expect(mockGetReview).toHaveBeenCalledWith('1');
+    expect(result).toEqual(reviewData);
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockGetReview.mockRejectedValue(new Error('Not found'));
+
+    await expect(getReview('999')).rejects.toThrow('Not found');
+  });
+});
+
+describe('useGetReview', () => {
+  it('id가 있으면 getReview를 호출하고 데이터를 반환한다', async () => {
+    const reviewData = { review_id: 1, title: '좋아요', content: '만족', light: 80, imageUrls: [] };
+    mockGetReview.mockResolvedValue(reviewData);
+
+    const { result } = renderHookWithProviders(() => useGetReview('1'));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetReview).toHaveBeenCalledWith('1');
+    expect(result.current.data).toEqual(reviewData);
+  });
+
+  it('id가 빈 문자열이면 쿼리가 비활성화된다', () => {
+    const { result } = renderHookWithProviders(() => useGetReview(''));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetReview).not.toHaveBeenCalled();
+  });
+
+  it('queryKey가 [review, id]이다', async () => {
+    mockGetReview.mockResolvedValue({});
+
+    const { queryClient } = renderHookWithProviders(() => useGetReview('5'));
+
+    await waitFor(() => expect(queryClient.getQueryState(['review', '5'])).toBeDefined());
+  });
+});

--- a/src/view/cancelTrade/api/__tests__/getReview.api.test.ts
+++ b/src/view/cancelTrade/api/__tests__/getReview.api.test.ts
@@ -1,0 +1,28 @@
+import { instance } from '~/shared/lib/axios';
+import { getReview } from '../getReview';
+
+jest.mock('~/shared/lib/axios', () => ({
+  instance: { get: jest.fn() },
+}));
+
+const mockGet = instance.get as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getReview', () => {
+  it('GET /review/detail/:id 응답 data를 반환한다', async () => {
+    const reviewData = { review_id: 1, title: '좋아요', content: '만족', light: 80, imageUrls: [] };
+    mockGet.mockResolvedValue({ data: reviewData });
+
+    const result = await getReview('1');
+
+    expect(mockGet).toHaveBeenCalledWith('/review/detail/1');
+    expect(result).toEqual(reviewData);
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockGet.mockRejectedValue(new Error('Not found'));
+
+    await expect(getReview('999')).rejects.toThrow('Not found');
+  });
+});

--- a/src/view/profile/api/__tests__/profile.api.test.ts
+++ b/src/view/profile/api/__tests__/profile.api.test.ts
@@ -1,0 +1,143 @@
+import { instance } from '~/shared/lib/axios';
+import { getMyProfile } from '../getMyProfile';
+import { getProfile } from '../getProfile';
+import { getMyPosts } from '../getMyPosts';
+import { getPost } from '../getPosts';
+import { updateProfile } from '../updateProfile';
+import { blockUser, unblockUser } from '../blockUser';
+import { getBlockList } from '../getBlockList';
+
+jest.mock('~/shared/lib/axios', () => ({
+  instance: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockGet = instance.get as jest.Mock;
+const mockPost = instance.post as jest.Mock;
+const mockPatch = instance.patch as jest.Mock;
+const mockDelete = instance.delete as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getMyProfile', () => {
+  it('GET /member 응답 data를 반환한다', async () => {
+    mockGet.mockResolvedValue({ data: { memberId: 1, nickname: '광산인' } });
+
+    const result = await getMyProfile();
+
+    expect(mockGet).toHaveBeenCalledWith('/member');
+    expect(result).toEqual({ memberId: 1, nickname: '광산인' });
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockGet.mockRejectedValue(new Error('Network error'));
+
+    await expect(getMyProfile()).rejects.toThrow('Network error');
+  });
+});
+
+describe('getProfile', () => {
+  it('GET /member/:id 응답 data를 반환한다', async () => {
+    mockGet.mockResolvedValue({ data: { memberId: 42, nickname: '상대방' } });
+
+    const result = await getProfile('42');
+
+    expect(mockGet).toHaveBeenCalledWith('/member/42');
+    expect(result).toEqual({ memberId: 42, nickname: '상대방' });
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockGet.mockRejectedValue(new Error('Not found'));
+
+    await expect(getProfile('99')).rejects.toThrow('Not found');
+  });
+});
+
+describe('getMyPosts', () => {
+  it('GET /post/current 응답 data를 반환한다', async () => {
+    mockGet.mockResolvedValue({ data: [{ id: 1, title: '내 게시글' }] });
+
+    const result = await getMyPosts();
+
+    expect(mockGet).toHaveBeenCalledWith('/post/current');
+    expect(result).toEqual([{ id: 1, title: '내 게시글' }]);
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockGet.mockRejectedValue(new Error('Unauthorized'));
+
+    await expect(getMyPosts()).rejects.toThrow('Unauthorized');
+  });
+});
+
+describe('getPost', () => {
+  it('GET /post/member/:id 응답 data를 반환한다', async () => {
+    mockGet.mockResolvedValue({ data: [{ id: 2, title: '상대방 게시글' }] });
+
+    const result = await getPost('5');
+
+    expect(mockGet).toHaveBeenCalledWith('/post/member/5');
+    expect(result).toEqual([{ id: 2, title: '상대방 게시글' }]);
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockGet.mockRejectedValue(new Error('Not found'));
+
+    await expect(getPost('999')).rejects.toThrow('Not found');
+  });
+});
+
+describe('updateProfile', () => {
+  const payload = { nickname: '새닉네임', specialties: ['요리'], description: '소개' };
+
+  it('PATCH /member로 프로필을 수정하고 data를 반환한다', async () => {
+    mockPatch.mockResolvedValue({ data: { success: true } });
+
+    const result = await updateProfile(payload);
+
+    expect(mockPatch).toHaveBeenCalledWith('/member', payload);
+    expect(result).toEqual({ success: true });
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockPatch.mockRejectedValue(new Error('Validation error'));
+
+    await expect(updateProfile(payload)).rejects.toThrow('Validation error');
+  });
+});
+
+describe('blockUser / unblockUser', () => {
+  it('blockUser — POST /block/:id 응답 data를 반환한다', async () => {
+    mockPost.mockResolvedValue({ data: { blocked: true } });
+
+    const result = await blockUser(7);
+
+    expect(mockPost).toHaveBeenCalledWith('/block/7');
+    expect(result).toEqual({ blocked: true });
+  });
+
+  it('unblockUser — DELETE /block/:id 응답 data를 반환한다', async () => {
+    mockDelete.mockResolvedValue({ data: { unblocked: true } });
+
+    const result = await unblockUser(7);
+
+    expect(mockDelete).toHaveBeenCalledWith('/block/7');
+    expect(result).toEqual({ unblocked: true });
+  });
+});
+
+describe('getBlockList', () => {
+  it('GET /block 응답 data를 반환한다', async () => {
+    const list = [{ memberId: 3, nickname: '차단된유저' }];
+    mockGet.mockResolvedValue({ data: list });
+
+    const result = await getBlockList();
+
+    expect(mockGet).toHaveBeenCalledWith('/block');
+    expect(result).toEqual(list);
+  });
+});

--- a/src/view/profile/model/__tests__/profile.model.test.ts
+++ b/src/view/profile/model/__tests__/profile.model.test.ts
@@ -1,0 +1,212 @@
+import { act, waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useGetMyProfile } from '../useGetMyProfile';
+import { useGetProfile } from '../useGetProfile';
+import { useGetMyPosts } from '../useGetMyPosts';
+import { useGetPosts } from '../useGetPosts';
+import { useUpdateProfile } from '../useUpdateProfile';
+import { useBlockUser } from '../useBlockUser';
+import { useGetBlockList } from '../useGetBlockList';
+import { getMyProfile } from '../../api/getMyProfile';
+import { getProfile } from '../../api/getProfile';
+import { getMyPosts } from '../../api/getMyPosts';
+import { getPost } from '../../api/getPosts';
+import { updateProfile } from '../../api/updateProfile';
+import { blockUser, unblockUser } from '../../api/blockUser';
+import { getBlockList } from '../../api/getBlockList';
+import Toast from 'react-native-toast-message';
+
+jest.mock('../../api/getMyProfile', () => ({ getMyProfile: jest.fn() }));
+jest.mock('../../api/getProfile', () => ({ getProfile: jest.fn() }));
+jest.mock('../../api/getMyPosts', () => ({ getMyPosts: jest.fn() }));
+jest.mock('../../api/getPosts', () => ({ getPost: jest.fn() }));
+jest.mock('../../api/updateProfile', () => ({ updateProfile: jest.fn() }));
+jest.mock('../../api/blockUser', () => ({ blockUser: jest.fn(), unblockUser: jest.fn() }));
+jest.mock('../../api/getBlockList', () => ({ getBlockList: jest.fn() }));
+jest.mock('expo-router', () => ({ router: { back: jest.fn() } }));
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockGetMyProfile = getMyProfile as jest.Mock;
+const mockGetProfile = getProfile as jest.Mock;
+const mockGetMyPosts = getMyPosts as jest.Mock;
+const mockGetPost = getPost as jest.Mock;
+const mockUpdateProfile = updateProfile as jest.Mock;
+const mockBlockUser = blockUser as jest.Mock;
+const mockUnblockUser = unblockUser as jest.Mock;
+const mockGetBlockList = getBlockList as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('useGetMyProfile', () => {
+  it('isMe=true이면 쿼리가 활성화된다', async () => {
+    mockGetMyProfile.mockResolvedValue({ memberId: 1, nickname: '나' });
+
+    const { result } = renderHookWithProviders(() => useGetMyProfile(true));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetMyProfile).toHaveBeenCalled();
+  });
+
+  it('isMe=false이면 쿼리가 비활성화된다', () => {
+    const { result } = renderHookWithProviders(() => useGetMyProfile(false));
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetMyProfile).not.toHaveBeenCalled();
+  });
+
+  it('queryKey가 [myProfile, current]이다', async () => {
+    mockGetMyProfile.mockResolvedValue({});
+
+    const { queryClient } = renderHookWithProviders(() => useGetMyProfile(true));
+
+    await waitFor(() => expect(queryClient.getQueryState(['myProfile', 'current'])).toBeDefined());
+  });
+});
+
+describe('useGetProfile', () => {
+  it('id가 있으면 getProfile을 호출한다', async () => {
+    mockGetProfile.mockResolvedValue({ memberId: 42 });
+
+    const { result } = renderHookWithProviders(() => useGetProfile('42'));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetProfile).toHaveBeenCalledWith('42');
+  });
+
+  it('id가 null이면 쿼리가 비활성화된다', () => {
+    const { result } = renderHookWithProviders(() => useGetProfile(null));
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useGetMyPosts', () => {
+  it('isMe=true이면 getMyPosts를 호출한다', async () => {
+    mockGetMyPosts.mockResolvedValue([]);
+
+    const { result } = renderHookWithProviders(() => useGetMyPosts(true));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetMyPosts).toHaveBeenCalled();
+  });
+
+  it('isMe=false이면 쿼리가 비활성화된다', () => {
+    const { result } = renderHookWithProviders(() => useGetMyPosts(false));
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useGetPosts', () => {
+  it('id가 있으면 getPost를 호출한다', async () => {
+    mockGetPost.mockResolvedValue([]);
+
+    const { result } = renderHookWithProviders(() => useGetPosts('5'));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetPost).toHaveBeenCalledWith('5');
+  });
+
+  it('id가 null이면 쿼리가 비활성화된다', () => {
+    const { result } = renderHookWithProviders(() => useGetPosts(null));
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useUpdateProfile', () => {
+  const payload = { nickname: '새닉', specialties: [], description: '' };
+
+  it('성공 시 profile 쿼리를 invalidate하고 Toast를 표시한다', async () => {
+    mockUpdateProfile.mockResolvedValue({});
+
+    const { result, queryClient } = renderHookWithProviders(() => useUpdateProfile());
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    await act(async () => {
+      result.current.mutate(payload);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+    expect(Toast.show).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('실패 시 에러 Toast를 표시한다', async () => {
+    mockUpdateProfile.mockRejectedValue(new Error('서버 오류'));
+
+    const { result } = renderHookWithProviders(() => useUpdateProfile());
+
+    await act(async () => {
+      result.current.mutate(payload);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', text2: '서버 오류' })
+    );
+  });
+});
+
+describe('useBlockUser', () => {
+  it('block 성공 시 blockList를 invalidate하고 Toast를 표시한다', async () => {
+    mockBlockUser.mockResolvedValue({});
+
+    const { result, queryClient } = renderHookWithProviders(() => useBlockUser(7));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    await act(async () => {
+      result.current.block.mutate();
+    });
+
+    await waitFor(() => expect(result.current.block.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['blockList'] });
+    expect(Toast.show).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('targetMemberId가 undefined이면 block mutation이 에러를 던진다', async () => {
+    const { result } = renderHookWithProviders(() => useBlockUser(undefined));
+
+    await act(async () => {
+      result.current.block.mutate();
+    });
+
+    await waitFor(() => expect(result.current.block.isError).toBe(true));
+  });
+
+  it('unblock 성공 시 blockList를 invalidate한다', async () => {
+    mockUnblockUser.mockResolvedValue({});
+
+    const { result, queryClient } = renderHookWithProviders(() => useBlockUser(7));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    await act(async () => {
+      result.current.unblock.mutate();
+    });
+
+    await waitFor(() => expect(result.current.unblock.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['blockList'] });
+  });
+});
+
+describe('useGetBlockList', () => {
+  it('getBlockList를 호출하고 데이터를 반환한다', async () => {
+    mockGetBlockList.mockResolvedValue([{ memberId: 3, nickname: '차단됨' }]);
+
+    const { result } = renderHookWithProviders(() => useGetBlockList());
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ memberId: 3, nickname: '차단됨' }]);
+  });
+
+  it('queryKey가 [blockList]이다', async () => {
+    mockGetBlockList.mockResolvedValue([]);
+
+    const { queryClient } = renderHookWithProviders(() => useGetBlockList());
+
+    await waitFor(() => expect(queryClient.getQueryState(['blockList'])).toBeDefined());
+  });
+});

--- a/src/view/reviews/__tests__/getReviews.test.ts
+++ b/src/view/reviews/__tests__/getReviews.test.ts
@@ -1,0 +1,60 @@
+import { instance } from '~/shared/lib/axios';
+import { getReceiveReview, getTossReview } from '../api/getReviews';
+import Toast from 'react-native-toast-message';
+
+jest.mock('~/shared/lib/axios', () => ({
+  instance: { get: jest.fn() },
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockGet = instance.get as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getReceiveReview', () => {
+  it('GET /review/:id 응답을 반환한다', async () => {
+    const mockResponse = { data: [{ id: 1, title: '후기' }] };
+    mockGet.mockResolvedValue(mockResponse);
+
+    const result = await getReceiveReview('3');
+
+    expect(mockGet).toHaveBeenCalledWith('/review/3');
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('API 실패 시 Toast 에러를 표시하고 에러를 던진다', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGet.mockRejectedValue(new Error('Server error'));
+
+    await expect(getReceiveReview('3')).rejects.toThrow('Server error');
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', text1: '후기 조회 실패' })
+    );
+  });
+});
+
+describe('getTossReview', () => {
+  it('GET /review 응답을 반환한다', async () => {
+    const mockResponse = { data: [{ id: 2, title: '내가 준 후기' }] };
+    mockGet.mockResolvedValue(mockResponse);
+
+    const result = await getTossReview();
+
+    expect(mockGet).toHaveBeenCalledWith('/review');
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('API 실패 시 Toast 에러를 표시하고 에러를 던진다', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGet.mockRejectedValue(new Error('Network error'));
+
+    await expect(getTossReview()).rejects.toThrow('Network error');
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', text1: '후기 조회 실패' })
+    );
+  });
+});

--- a/src/widget/cancelTrade/__tests__/cancelTrade.test.ts
+++ b/src/widget/cancelTrade/__tests__/cancelTrade.test.ts
@@ -1,0 +1,157 @@
+import { act, waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { cancelTrade } from '../api/cancelTrade';
+import { useCancelTrade } from '../model/useCancelTrade';
+import Toast from 'react-native-toast-message';
+
+jest.mock('../api/cancelTrade', () => ({
+  cancelTrade: jest.fn(),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+jest.mock('~/shared/ui/ImageUploader', () => ({}));
+
+const mockCancelTrade = cancelTrade as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('cancelTrade API', () => {
+  it('cancelTrade를 호출하면 응답을 반환한다', async () => {
+    const mockRes = { status: 200, data: { success: true } };
+    mockCancelTrade.mockResolvedValue(mockRes);
+
+    const result = await cancelTrade('철회 사유', [1, 2], 99);
+
+    expect(mockCancelTrade).toHaveBeenCalledWith('철회 사유', [1, 2], 99);
+    expect(result).toEqual(mockRes);
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockCancelTrade.mockRejectedValue(new Error('Server error'));
+
+    await expect(cancelTrade('사유', [], 1)).rejects.toThrow('Server error');
+  });
+});
+
+describe('useCancelTrade', () => {
+  it('초기 상태: reason은 빈 문자열, imageIds는 빈 배열이다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    expect(result.current.reason).toBe('');
+    expect(result.current.imageIds).toEqual([]);
+  });
+
+  it('setReason으로 reason을 업데이트한다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('철회 사유입니다');
+    });
+
+    expect(result.current.reason).toBe('철회 사유입니다');
+  });
+
+  it('setImageIds로 imageIds를 업데이트한다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setImageIds([10, 20]);
+    });
+
+    expect(result.current.imageIds).toEqual([10, 20]);
+  });
+
+  it('reason이 비어있고 productId가 있으면 canSubmit이 false이다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    expect(result.current.canSubmit).toBe(false);
+  });
+
+  it('reason이 있으면 canSubmit이 true이다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('충분한 사유');
+    });
+
+    expect(result.current.canSubmit).toBe(true);
+  });
+
+  it('handleSubmit 성공 시 성공 Toast를 표시하고 onSuccess를 호출한다', async () => {
+    mockCancelTrade.mockResolvedValue({});
+    const onSuccess = jest.fn();
+
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 5, onSuccess }));
+
+    act(() => {
+      result.current.setReason('철회 사유');
+    });
+
+    await act(async () => {
+      result.current.handleSubmit('철회 사유');
+    });
+
+    await waitFor(() =>
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', text1: '거래철회 완료' })
+      )
+    );
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('handleSubmit 실패 시 에러 Toast를 표시한다', async () => {
+    mockCancelTrade.mockRejectedValue(new Error('철회 실패'));
+
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 5 }));
+
+    act(() => {
+      result.current.setReason('사유');
+    });
+
+    await act(async () => {
+      result.current.handleSubmit('사유');
+    });
+
+    await waitFor(() =>
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', text1: '거래철회 실패', text2: '철회 실패' })
+      )
+    );
+  });
+
+  it('resetForm으로 상태를 초기화한다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('사유');
+      result.current.setImageIds([1]);
+    });
+
+    act(() => {
+      result.current.resetForm();
+    });
+
+    expect(result.current.reason).toBe('');
+    expect(result.current.imageIds).toEqual([]);
+  });
+
+  it('productId가 없으면 handleSubmit 시 에러 Toast를 표시한다', async () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: undefined }));
+
+    act(() => {
+      result.current.setReason('사유');
+    });
+
+    act(() => {
+      result.current.handleSubmit('사유');
+    });
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', text1: '거래철회 실패' })
+    );
+  });
+});

--- a/src/widget/cancelTrade/__tests__/cancelTrade.test.ts
+++ b/src/widget/cancelTrade/__tests__/cancelTrade.test.ts
@@ -71,6 +71,22 @@ describe('useCancelTrade', () => {
     expect(result.current.canSubmit).toBe(false);
   });
 
+  it('reason이 공백만 있고 productId가 있으면 canSubmit이 false이다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('   ');
+    });
+
+    expect(result.current.canSubmit).toBe(false);
+  });
+
+  it('productId가 없고 reason도 비어있으면 canSubmit이 true이다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: undefined }));
+
+    expect(result.current.canSubmit).toBe(true);
+  });
+
   it('reason이 있으면 canSubmit이 true이다', () => {
     const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
 
@@ -123,6 +139,30 @@ describe('useCancelTrade', () => {
     );
   });
 
+  it('handleSubmit non-Error 실패 시 기본 오류 메시지 Toast를 표시한다', async () => {
+    mockCancelTrade.mockRejectedValue('string error');
+
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 5 }));
+
+    act(() => {
+      result.current.setReason('사유');
+    });
+
+    await act(async () => {
+      result.current.handleSubmit('사유');
+    });
+
+    await waitFor(() =>
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text1: '거래철회 실패',
+          text2: '거래철회 처리 중 오류가 발생했습니다.',
+        })
+      )
+    );
+  });
+
   it('resetForm으로 상태를 초기화한다', () => {
     const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
 
@@ -152,6 +192,111 @@ describe('useCancelTrade', () => {
 
     expect(Toast.show).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'error', text1: '거래철회 실패' })
+    );
+  });
+
+  it('setImageUploadState로 imageUploadState를 업데이트한다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setImageUploadState({
+        totalImages: 0,
+        uploadingCount: 0,
+        uploadedCount: 0,
+        hasUploadingImages: false,
+        hasFailedImages: false,
+      });
+    });
+
+    expect(result.current.imageUploadState).toEqual({
+      totalImages: 0,
+      uploadingCount: 0,
+      uploadedCount: 0,
+      hasUploadingImages: false,
+      hasFailedImages: false,
+    });
+  });
+
+  it('imageUploadState.hasUploadingImages=true이면 canSubmit이 false이다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('사유');
+      result.current.setImageUploadState({
+        totalImages: 1,
+        uploadingCount: 1,
+        uploadedCount: 0,
+        hasUploadingImages: true,
+        hasFailedImages: false,
+      });
+    });
+
+    expect(result.current.canSubmit).toBe(false);
+  });
+
+  it('imageUploadState.hasFailedImages=true이면 canSubmit이 false이다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('사유');
+      result.current.setImageUploadState({
+        totalImages: 1,
+        uploadingCount: 0,
+        uploadedCount: 0,
+        hasUploadingImages: false,
+        hasFailedImages: true,
+      });
+    });
+
+    expect(result.current.canSubmit).toBe(false);
+  });
+
+  it('이미지 업로드 중이면 handleSubmit 시 대기 Toast를 표시한다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('사유');
+      result.current.setImageUploadState({
+        totalImages: 1,
+        uploadingCount: 1,
+        uploadedCount: 0,
+        hasUploadingImages: true,
+        hasFailedImages: false,
+      });
+    });
+
+    act(() => {
+      result.current.handleSubmit('사유');
+    });
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        text1: '이미지 업로드가 완료될 때까지 기다려주세요.',
+      })
+    );
+  });
+
+  it('이미지 업로드 실패 상태이면 handleSubmit 시 실패 Toast를 표시한다', () => {
+    const { result } = renderHookWithProviders(() => useCancelTrade({ productId: 1 }));
+
+    act(() => {
+      result.current.setReason('사유');
+      result.current.setImageUploadState({
+        totalImages: 1,
+        uploadingCount: 0,
+        uploadedCount: 0,
+        hasUploadingImages: false,
+        hasFailedImages: true,
+      });
+    });
+
+    act(() => {
+      result.current.handleSubmit('사유');
+    });
+
+    expect(Toast.show).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', text1: '이미지 업로드 실패' })
     );
   });
 });

--- a/src/widget/cancelTrade/api/__tests__/cancelTrade.api.test.ts
+++ b/src/widget/cancelTrade/api/__tests__/cancelTrade.api.test.ts
@@ -1,0 +1,31 @@
+import { instance } from '~/shared/lib/axios';
+import { cancelTrade } from '../cancelTrade';
+
+jest.mock('~/shared/lib/axios', () => ({
+  instance: { post: jest.fn() },
+}));
+
+const mockPost = instance.post as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('cancelTrade', () => {
+  it('POST /trade/cancel/:productId로 요청하고 응답을 반환한다', async () => {
+    const mockRes = { status: 200, data: { success: true } };
+    mockPost.mockResolvedValue(mockRes);
+
+    const result = await cancelTrade('철회 사유', [1, 2], 99);
+
+    expect(mockPost).toHaveBeenCalledWith('/trade/cancel/99', {
+      imageIds: [1, 2],
+      reason: '철회 사유',
+    });
+    expect(result).toEqual(mockRes);
+  });
+
+  it('API 실패 시 에러를 전파한다', async () => {
+    mockPost.mockRejectedValue(new Error('Server error'));
+
+    await expect(cancelTrade('사유', [], 1)).rejects.toThrow('Server error');
+  });
+});

--- a/src/widget/chat/model/__tests__/useChatAction.test.ts
+++ b/src/widget/chat/model/__tests__/useChatAction.test.ts
@@ -55,7 +55,7 @@ describe('useChatAction', () => {
         { createdAt: '2026-01-02T15:30:00Z' },
       ];
 
-      const formatted = result.current.formatLastMessageDate(messages as never[]);
+      const formatted = result.current.formatLastMessageDate(messages as any[]);
 
       expect(typeof formatted).toBe('string');
       expect(formatted.length).toBeGreaterThan(0);

--- a/src/widget/chat/model/__tests__/useChatAction.test.ts
+++ b/src/widget/chat/model/__tests__/useChatAction.test.ts
@@ -1,0 +1,64 @@
+import { act } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useChatAction } from '../useChatActions';
+
+const mockPush = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('useChatAction', () => {
+  const otherUserInfo = { nickname: '광산주민', id: 42 };
+
+  describe('navigationHandlers', () => {
+    it('goToProfile을 호출하면 /profile로 이동한다', () => {
+      const { result } = renderHookWithProviders(() => useChatAction({ otherUserInfo }));
+
+      act(() => result.current.navigationHandlers.goToProfile(1));
+
+      expect(mockPush).toHaveBeenCalledWith('/profile');
+    });
+
+    it('goToOtherUserProfile을 호출하면 /profile?id=:id로 이동한다', () => {
+      const { result } = renderHookWithProviders(() => useChatAction({ otherUserInfo }));
+
+      act(() => result.current.navigationHandlers.goToOtherUserProfile());
+
+      expect(mockPush).toHaveBeenCalledWith('/profile?id=42');
+    });
+
+    it('otherUserInfo.id가 없으면 goToOtherUserProfile이 push를 호출하지 않는다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatAction({ otherUserInfo: { nickname: '상대방' } })
+      );
+
+      act(() => result.current.navigationHandlers.goToOtherUserProfile());
+
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('formatLastMessageDate', () => {
+    it('메시지가 없으면 "대화를 시작해보세요"를 반환한다', () => {
+      const { result } = renderHookWithProviders(() => useChatAction({ otherUserInfo }));
+
+      expect(result.current.formatLastMessageDate([])).toBe('대화를 시작해보세요');
+    });
+
+    it('메시지가 있으면 마지막 메시지의 날짜를 포맷해 반환한다', () => {
+      const { result } = renderHookWithProviders(() => useChatAction({ otherUserInfo }));
+
+      const messages = [
+        { createdAt: '2026-01-01T10:00:00Z' },
+        { createdAt: '2026-01-02T15:30:00Z' },
+      ];
+
+      const formatted = result.current.formatLastMessageDate(messages as never[]);
+
+      expect(typeof formatted).toBe('string');
+      expect(formatted.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/widget/chat/model/__tests__/useChatInput.test.ts
+++ b/src/widget/chat/model/__tests__/useChatInput.test.ts
@@ -1,4 +1,3 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { act } from '@testing-library/react-native';
 import { renderHookWithProviders } from '~/test-utils';
 import { useChatInput } from '../useChatInput';

--- a/src/widget/chat/model/__tests__/useChatInput.test.ts
+++ b/src/widget/chat/model/__tests__/useChatInput.test.ts
@@ -208,5 +208,41 @@ describe('useChatInput', () => {
       ]);
       expect(result.current.isUploading).toBe(false);
     });
+
+    it('이미지 선택 중 오류 시 selectedImages가 변하지 않고 isUploading이 false이다', async () => {
+      mockRequestPermission.mockResolvedValue({ granted: true });
+      mockLaunchImageLibrary.mockRejectedValue(new Error('picker error'));
+
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      await act(async () => {
+        await result.current.handleImagePicker();
+      });
+
+      expect(result.current.selectedImages).toEqual([]);
+      expect(result.current.isUploading).toBe(false);
+    });
+
+    it('이미지 업로드 실패 시 selectedImages가 변하지 않고 isUploading이 false이다', async () => {
+      setupUploadMock(jest.fn().mockRejectedValue(new Error('upload error')));
+      mockRequestPermission.mockResolvedValue({ granted: true });
+      mockLaunchImageLibrary.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file://photo.jpg' }],
+      });
+
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      await act(async () => {
+        try {
+          await result.current.handleImagePicker();
+        } catch {
+          // uploadImage re-throws after showing Alert
+        }
+      });
+
+      expect(result.current.selectedImages).toEqual([]);
+      expect(result.current.isUploading).toBe(false);
+    });
   });
 });

--- a/src/widget/chat/model/__tests__/useChatInput.test.ts
+++ b/src/widget/chat/model/__tests__/useChatInput.test.ts
@@ -1,0 +1,213 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { act } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useChatInput } from '../useChatInput';
+
+import { useUploadImage } from '@/shared/model/useUploadImage';
+import * as ImagePicker from 'expo-image-picker';
+
+jest.mock('@/shared/model/useUploadImage', () => ({
+  useUploadImage: jest.fn(),
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+}));
+
+const mockUseUploadImage = useUploadImage as jest.Mock;
+const mockRequestPermission = ImagePicker.requestMediaLibraryPermissionsAsync as jest.Mock;
+const mockLaunchImageLibrary = ImagePicker.launchImageLibraryAsync as jest.Mock;
+
+const setupUploadMock = (mutateAsync = jest.fn()) => {
+  mockUseUploadImage.mockReturnValue({ mutateAsync });
+  return mutateAsync;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupUploadMock();
+});
+
+describe('useChatInput', () => {
+  const onSendMessage = jest.fn();
+
+  describe('초기 상태', () => {
+    it('textMessage는 빈 문자열, selectedImages는 빈 배열이다', () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      expect(result.current.textMessage).toBe('');
+      expect(result.current.selectedImages).toEqual([]);
+      expect(result.current.isUploading).toBe(false);
+      expect(result.current.isSending).toBe(false);
+    });
+  });
+
+  describe('canSend', () => {
+    it('textMessage와 selectedImages가 모두 비어있으면 false이다', () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      expect(result.current.canSend).toBe(false);
+    });
+
+    it('textMessage가 있으면 canSend가 true이다', () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      act(() => result.current.updateMessage('안녕'));
+
+      expect(result.current.canSend).toBe(true);
+    });
+
+    it('공백만 있으면 canSend가 false이다', () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      act(() => result.current.updateMessage('   '));
+
+      expect(result.current.canSend).toBe(false);
+    });
+
+    it('disabled=true이면 텍스트가 있어도 canSend가 false이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatInput({ onSendMessage, disabled: true })
+      );
+
+      act(() => result.current.updateMessage('안녕'));
+
+      expect(result.current.canSend).toBe(false);
+    });
+  });
+
+  describe('updateMessage', () => {
+    it('textMessage를 업데이트한다', () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      act(() => result.current.updateMessage('새 메시지'));
+
+      expect(result.current.textMessage).toBe('새 메시지');
+    });
+  });
+
+  describe('removeImage', () => {
+    it('존재하지 않는 imageId로 removeImage를 호출해도 안전하다', () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      act(() => result.current.removeImage(999));
+
+      expect(result.current.selectedImages).toEqual([]);
+    });
+  });
+
+  describe('handleSendMessage', () => {
+    it('canSend가 false이면 onSendMessage를 호출하지 않는다', async () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      await act(async () => {
+        await result.current.handleSendMessage();
+      });
+
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it('텍스트가 있으면 onSendMessage를 호출하고 textMessage를 초기화한다', async () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      act(() => result.current.updateMessage('보낼 메시지'));
+
+      await act(async () => {
+        await result.current.handleSendMessage();
+      });
+
+      expect(onSendMessage).toHaveBeenCalledWith('보낼 메시지', []);
+      expect(result.current.textMessage).toBe('');
+    });
+
+    it('앞뒤 공백은 trim하여 전달한다', async () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      act(() => result.current.updateMessage('  텍스트  '));
+
+      await act(async () => {
+        await result.current.handleSendMessage();
+      });
+
+      expect(onSendMessage).toHaveBeenCalledWith('텍스트', []);
+    });
+  });
+
+  describe('resetInput', () => {
+    it('모든 상태를 초기화한다', () => {
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      act(() => result.current.updateMessage('텍스트'));
+      act(() => result.current.resetInput());
+
+      expect(result.current.textMessage).toBe('');
+      expect(result.current.selectedImages).toEqual([]);
+      expect(result.current.isUploading).toBe(false);
+      expect(result.current.isSending).toBe(false);
+    });
+  });
+
+  describe('handleImagePicker', () => {
+    it('disabled=true이면 아무것도 하지 않는다', async () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatInput({ onSendMessage, disabled: true })
+      );
+
+      await act(async () => {
+        await result.current.handleImagePicker();
+      });
+
+      expect(mockRequestPermission).not.toHaveBeenCalled();
+    });
+
+    it('권한이 없으면 이미지를 추가하지 않는다', async () => {
+      mockRequestPermission.mockResolvedValue({ granted: false });
+
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      await act(async () => {
+        await result.current.handleImagePicker();
+      });
+
+      expect(result.current.selectedImages).toEqual([]);
+      expect(mockLaunchImageLibrary).not.toHaveBeenCalled();
+    });
+
+    it('이미지 선택이 취소되면 selectedImages가 변하지 않는다', async () => {
+      mockRequestPermission.mockResolvedValue({ granted: true });
+      mockLaunchImageLibrary.mockResolvedValue({ canceled: true, assets: [] });
+
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      await act(async () => {
+        await result.current.handleImagePicker();
+      });
+
+      expect(result.current.selectedImages).toEqual([]);
+    });
+
+    it('권한과 선택 성공 시 이미지를 업로드하고 selectedImages에 추가한다', async () => {
+      const mockMutateAsync = setupUploadMock(
+        jest.fn().mockResolvedValue({ imageId: 10, imageUrl: 'https://example.com/img.jpg' })
+      );
+      mockRequestPermission.mockResolvedValue({ granted: true });
+      mockLaunchImageLibrary.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file://photo.jpg' }],
+      });
+
+      const { result } = renderHookWithProviders(() => useChatInput({ onSendMessage }));
+
+      await act(async () => {
+        await result.current.handleImagePicker();
+      });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith('file://photo.jpg');
+      expect(result.current.selectedImages).toEqual([
+        { imageId: 10, imageUrl: 'https://example.com/img.jpg', localUri: 'file://photo.jpg' },
+      ]);
+      expect(result.current.isUploading).toBe(false);
+    });
+  });
+});

--- a/src/widget/chat/model/__tests__/useChatMessages.test.ts
+++ b/src/widget/chat/model/__tests__/useChatMessages.test.ts
@@ -1,4 +1,4 @@
-import { renderHookWithProviders } from '~/test-utils';
+import { renderHookWithProviders, createQueryClient } from '~/test-utils';
 import { useChatMessages } from '../useChatMessages';
 
 import { useChatMessages as useChatMessagesEntity } from '~/entity/chat';
@@ -86,6 +86,26 @@ describe('useChatMessages', () => {
 
       expect(result.current.otherUserInfo).toEqual({ nickname: '광산주민', id: 42 });
     });
+
+    it('캐시에 해당 room이 있으면 member 정보를 우선 사용한다', () => {
+      const preloadedClient = createQueryClient();
+      preloadedClient.setQueryData(
+        ['chatRooms', 'list'],
+        [
+          {
+            roomId: 'room-1',
+            member: { nickname: '캐시닉네임', memberId: 99 },
+          },
+        ]
+      );
+
+      const { result } = renderHookWithProviders(
+        () => useChatMessages({ roomId: 'room-1' as any }),
+        { queryClient: preloadedClient }
+      );
+
+      expect(result.current.otherUserInfo).toEqual({ nickname: '캐시닉네임', id: 99 });
+    });
   });
 
   describe('connectionState', () => {
@@ -156,6 +176,51 @@ describe('useChatMessages', () => {
       result.current.messageHandlers.sendMessage(null, []);
 
       expect(mockResilientSend).not.toHaveBeenCalled();
+    });
+
+    it('content가 빈 문자열이고 imageIds도 없으면 resilientSendMessage를 호출하지 않는다', () => {
+      const mockResilientSend = jest.fn();
+      mockUseResilientMessageSender.mockReturnValue({ sendMessage: mockResilientSend });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      result.current.messageHandlers.sendMessage('', []);
+
+      expect(mockResilientSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('messageHandlers.renderMessage', () => {
+    it('renderMessage는 항상 null을 반환한다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      const output = result.current.messageHandlers.renderMessage({
+        item: { id: 1, content: '테스트' } as any,
+      });
+
+      expect(output).toBeNull();
+    });
+  });
+
+  describe('scrollToEnd', () => {
+    it('scrollToEnd 함수를 반환한다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(typeof result.current.scrollToEnd).toBe('function');
+    });
+
+    it('flatListRef가 없어도 scrollToEnd 호출 시 오류가 없다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      result.current.scrollToEnd(false);
     });
   });
 

--- a/src/widget/chat/model/__tests__/useChatMessages.test.ts
+++ b/src/widget/chat/model/__tests__/useChatMessages.test.ts
@@ -1,0 +1,183 @@
+import { renderHookWithProviders } from '~/test-utils';
+import { useChatMessages } from '../useChatMessages';
+
+import { useChatMessages as useChatMessagesEntity } from '~/entity/chat';
+import { useChatSocket } from '~/entity/chat/model/useChatSocket';
+import { useResilientMessageSender } from '~/entity/chat/hooks/useResilientMessageSender';
+import { extractOtherUserInfo, ensureMessagesArray } from '~/shared/lib/userUtils';
+
+jest.mock('~/entity/chat', () => ({
+  useChatMessages: jest.fn(),
+}));
+
+jest.mock('~/entity/chat/model/useChatSocket', () => ({
+  useChatSocket: jest.fn(),
+}));
+
+jest.mock('~/entity/chat/hooks/useResilientMessageSender', () => ({
+  useResilientMessageSender: jest.fn(),
+}));
+
+jest.mock('~/shared/lib/userUtils', () => ({
+  extractOtherUserInfo: jest.fn(),
+  ensureMessagesArray: jest.fn(),
+}));
+
+const mockUseChatMessagesEntity = useChatMessagesEntity as jest.Mock;
+const mockUseChatSocket = useChatSocket as jest.Mock;
+const mockUseResilientMessageSender = useResilientMessageSender as jest.Mock;
+const mockExtractOtherUserInfo = extractOtherUserInfo as jest.Mock;
+const mockEnsureMessagesArray = ensureMessagesArray as jest.Mock;
+
+const setupMocks = () => {
+  mockUseChatMessagesEntity.mockReturnValue({ data: [], isLoading: false, isError: false });
+  mockUseChatSocket.mockReturnValue({
+    sendMessage: jest.fn(),
+    markRoomAsRead: jest.fn(),
+    connectionState: 'connected',
+  });
+  mockUseResilientMessageSender.mockReturnValue({ sendMessage: jest.fn() });
+  mockEnsureMessagesArray.mockReturnValue([]);
+  mockExtractOtherUserInfo.mockReturnValue({ nickname: '상대방', id: undefined });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMocks();
+});
+
+describe('useChatMessages', () => {
+  describe('초기 상태', () => {
+    it('messages, isLoading, isError, connectionState를 반환한다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(result.current.messages).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(false);
+      expect(result.current.connectionState).toBe('connected');
+    });
+
+    it('flatListRef를 반환한다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(result.current.flatListRef).toBeDefined();
+    });
+
+    it('markRoomAsRead 함수를 반환한다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(typeof result.current.markRoomAsRead).toBe('function');
+    });
+  });
+
+  describe('otherUserInfo', () => {
+    it('캐시에 roomData가 없으면 extractOtherUserInfo를 사용한다', () => {
+      mockExtractOtherUserInfo.mockReturnValue({ nickname: '광산주민', id: 42 });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(result.current.otherUserInfo).toEqual({ nickname: '광산주민', id: 42 });
+    });
+  });
+
+  describe('connectionState', () => {
+    it('disconnected 상태를 반환한다', () => {
+      mockUseChatSocket.mockReturnValue({
+        sendMessage: jest.fn(),
+        markRoomAsRead: jest.fn(),
+        connectionState: 'disconnected',
+      });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(result.current.connectionState).toBe('disconnected');
+    });
+
+    it('connecting 상태를 반환한다', () => {
+      mockUseChatSocket.mockReturnValue({
+        sendMessage: jest.fn(),
+        markRoomAsRead: jest.fn(),
+        connectionState: 'connecting',
+      });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(result.current.connectionState).toBe('connecting');
+    });
+  });
+
+  describe('messageHandlers.sendMessage', () => {
+    it('imageIds가 있으면 IMAGE 타입으로 resilientSendMessage를 호출한다', () => {
+      const mockResilientSend = jest.fn();
+      mockUseResilientMessageSender.mockReturnValue({ sendMessage: mockResilientSend });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      result.current.messageHandlers.sendMessage('내용', [1, 2]);
+
+      expect(mockResilientSend).toHaveBeenCalledWith('내용', 'IMAGE', [1, 2]);
+    });
+
+    it('imageIds가 없고 content가 있으면 TEXT 타입으로 resilientSendMessage를 호출한다', () => {
+      const mockResilientSend = jest.fn();
+      mockUseResilientMessageSender.mockReturnValue({ sendMessage: mockResilientSend });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      result.current.messageHandlers.sendMessage('안녕하세요', []);
+
+      expect(mockResilientSend).toHaveBeenCalledWith('안녕하세요', 'TEXT', []);
+    });
+
+    it('content가 null이고 imageIds도 없으면 resilientSendMessage를 호출하지 않는다', () => {
+      const mockResilientSend = jest.fn();
+      mockUseResilientMessageSender.mockReturnValue({ sendMessage: mockResilientSend });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      result.current.messageHandlers.sendMessage(null, []);
+
+      expect(mockResilientSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isLoading / isError', () => {
+    it('isLoading=true를 반환한다', () => {
+      mockUseChatMessagesEntity.mockReturnValue({ data: [], isLoading: true, isError: false });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('isError=true를 반환한다', () => {
+      mockUseChatMessagesEntity.mockReturnValue({ data: [], isLoading: false, isError: true });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatMessages({ roomId: 'room-1' as any })
+      );
+
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/src/widget/chat/model/__tests__/useChatUIState.test.ts
+++ b/src/widget/chat/model/__tests__/useChatUIState.test.ts
@@ -1,0 +1,172 @@
+import { renderHookWithProviders } from '~/test-utils';
+import { useChatUIState } from '../useChatUIState';
+
+import { useChatRoomData } from '~/entity/chat/model/useChatRoomData';
+import { useGetItem } from '~/entity/post/model/useGetItem';
+import { useGetMyInformation } from '~/entity/main/model/useGetMyInformation';
+
+jest.mock('~/entity/chat/model/useChatRoomData', () => ({
+  useChatRoomData: jest.fn(),
+}));
+
+jest.mock('~/entity/post/model/useGetItem', () => ({
+  useGetItem: jest.fn(),
+}));
+
+jest.mock('~/entity/main/model/useGetMyInformation', () => ({
+  useGetMyInformation: jest.fn(),
+}));
+
+jest.mock('~/widget/write/model/mode', () => ({
+  MODE: { GIVER: 'GIVER', RECEIVER: 'RECEIVER' },
+}));
+
+const mockUseChatRoomData = useChatRoomData as jest.Mock;
+const mockUseGetItem = useGetItem as jest.Mock;
+const mockUseGetMyInformation = useGetMyInformation as jest.Mock;
+
+const setupMocks = (overrides: { roomData?: any; productDetail?: any; myInfo?: any } = {}) => {
+  mockUseChatRoomData.mockReturnValue({ data: overrides.roomData ?? null });
+  mockUseGetItem.mockReturnValue({ data: overrides.productDetail ?? null, isLoading: false });
+  mockUseGetMyInformation.mockReturnValue({ data: overrides.myInfo ?? { nickname: '내닉네임' } });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMocks();
+});
+
+const defaultProps = {
+  roomId: 'room-1' as any,
+  otherUserInfo: { nickname: '상대방', id: 42 },
+  hasTradeRequest: false,
+  shouldShowButtons: false,
+  handleTradeAccept: jest.fn(),
+  handleReservation: jest.fn(),
+  handleCancelReservation: jest.fn(),
+};
+
+describe('useChatUIState', () => {
+  describe('componentState', () => {
+    it('headerTitle은 otherUserInfo.nickname이다', () => {
+      const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
+
+      expect(result.current.componentState.headerTitle).toBe('상대방');
+    });
+  });
+
+  describe('tradeRequestInfo', () => {
+    it('roomData에 product.id가 있으면 productId를 반환한다', () => {
+      setupMocks({ roomData: { product: { id: 5 } } });
+
+      const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
+
+      expect(result.current.tradeRequestInfo.productId).toBe(5);
+    });
+
+    it('sellerId는 otherUserInfo.id이다', () => {
+      const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
+
+      expect(result.current.tradeRequestInfo.sellerId).toBe(42);
+    });
+
+    it('roomData가 없으면 productId가 undefined이다', () => {
+      const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
+
+      expect(result.current.tradeRequestInfo.productId).toBeUndefined();
+    });
+  });
+
+  describe('menuConfig', () => {
+    it('productDetail.mode가 GIVER이면 isGiverMode가 true이다', () => {
+      setupMocks({ productDetail: { mode: 'GIVER' } });
+
+      const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
+
+      expect(result.current.menuConfig.isGiverMode).toBe(true);
+      expect(result.current.menuConfig.shouldShowMenuButton).toBe(true);
+    });
+
+    it('productDetail.mode가 RECEIVER이면 isGiverMode가 false이다', () => {
+      setupMocks({ productDetail: { mode: 'RECEIVER' } });
+
+      const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
+
+      expect(result.current.menuConfig.isGiverMode).toBe(false);
+      expect(result.current.menuConfig.shouldShowMenuButton).toBe(false);
+    });
+
+    it('productDetail이 없으면 shouldShowMenuButton이 false이다', () => {
+      const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
+
+      expect(result.current.menuConfig.shouldShowMenuButton).toBe(false);
+    });
+  });
+
+  describe('tradeEmbedConfig', () => {
+    it('hasTradeRequest=true이면 shouldShow가 true이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatUIState({ ...defaultProps, hasTradeRequest: true })
+      );
+
+      expect(result.current.tradeEmbedConfig.shouldShow).toBe(true);
+    });
+
+    it('hasTradeRequest=false이면 shouldShow가 false이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatUIState({ ...defaultProps, hasTradeRequest: false })
+      );
+
+      expect(result.current.tradeEmbedConfig.shouldShow).toBe(false);
+    });
+
+    it('shouldShowButtons=false이면 핸들러들이 undefined이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatUIState({ ...defaultProps, shouldShowButtons: false })
+      );
+
+      expect(result.current.tradeEmbedConfig.onTradeAccept).toBeUndefined();
+      expect(result.current.tradeEmbedConfig.onReservation).toBeUndefined();
+      expect(result.current.tradeEmbedConfig.onCancelReservation).toBeUndefined();
+    });
+
+    it('shouldShowButtons=true이면 핸들러들이 제공된다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatUIState({ ...defaultProps, shouldShowButtons: true })
+      );
+
+      expect(result.current.tradeEmbedConfig.onTradeAccept).toBeDefined();
+      expect(result.current.tradeEmbedConfig.onReservation).toBeDefined();
+      expect(result.current.tradeEmbedConfig.onCancelReservation).toBeDefined();
+    });
+
+    it('shouldShowButtons=true이면 requestorNickname이 otherUserInfo.nickname이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useChatUIState({ ...defaultProps, shouldShowButtons: true })
+      );
+
+      expect(result.current.tradeEmbedConfig.requestorNickname).toBe('상대방');
+    });
+
+    it('shouldShowButtons=false이면 requestorNickname이 myInfo.nickname이다', () => {
+      setupMocks({ myInfo: { nickname: '나의닉네임' } });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatUIState({ ...defaultProps, shouldShowButtons: false })
+      );
+
+      expect(result.current.tradeEmbedConfig.requestorNickname).toBe('나의닉네임');
+    });
+
+    it('shouldShowButtons=false이고 myInfo가 없으면 requestorNickname이 "나"이다', () => {
+      setupMocks({ myInfo: null });
+      mockUseGetMyInformation.mockReturnValue({ data: null });
+
+      const { result } = renderHookWithProviders(() =>
+        useChatUIState({ ...defaultProps, shouldShowButtons: false })
+      );
+
+      expect(result.current.tradeEmbedConfig.requestorNickname).toBe('나');
+    });
+  });
+});

--- a/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
+++ b/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
@@ -243,5 +243,64 @@ describe('useTradeHandlers', () => {
 
       expect(mockCancelReservation).not.toHaveBeenCalled();
     });
+
+    it('non-Error 실패 시 알 수 없는 오류 메시지를 표시한다', async () => {
+      mockCancelReservation.mockRejectedValue('string error');
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleCancelReservation();
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text2: '알 수 없는 오류가 발생했습니다.',
+        })
+      );
+    });
+  });
+
+  describe('non-Error 거부 메시지', () => {
+    it('handleTradeAccept non-Error 실패 시 알 수 없는 오류 메시지를 표시한다', async () => {
+      mockRequestTrade.mockRejectedValue('string error');
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleTradeAccept();
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text2: '알 수 없는 오류가 발생했습니다.',
+        })
+      );
+    });
+
+    it('handleReservation non-Error 실패 시 알 수 없는 오류 메시지를 표시한다', async () => {
+      mockMakeReservation.mockRejectedValue('string error');
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleReservation();
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          text2: '알 수 없는 오류가 발생했습니다.',
+        })
+      );
+    });
   });
 });

--- a/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
+++ b/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
@@ -1,0 +1,247 @@
+import { act } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useTradeHandlers } from '../useTradeHandlers';
+import { requestTrade } from '~/entity/post/api/requestTrade';
+import { makeReservation } from '~/entity/post/api/makeReservation';
+import { cancelReservation } from '~/entity/post/api/cancelReservation';
+import Toast from 'react-native-toast-message';
+
+jest.mock('~/entity/post/api/requestTrade', () => ({ requestTrade: jest.fn() }));
+jest.mock('~/entity/post/api/makeReservation', () => ({ makeReservation: jest.fn() }));
+jest.mock('~/entity/post/api/cancelReservation', () => ({ cancelReservation: jest.fn() }));
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockRequestTrade = requestTrade as jest.Mock;
+const mockMakeReservation = makeReservation as jest.Mock;
+const mockCancelReservation = cancelReservation as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+const makeRoomData = (overrides: Record<string, any> = {}) => ({
+  product: {
+    id: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+    isCompletable: true,
+    ...overrides,
+  },
+});
+
+describe('useTradeHandlers', () => {
+  const otherUserInfo = { nickname: '상대방', id: 42 };
+
+  describe('hasTradeRequest', () => {
+    it('product.createdAt이 있으면 hasTradeRequest가 true이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      expect(result.current.hasTradeRequest).toBe(true);
+    });
+
+    it('product.createdAt이 null이면 hasTradeRequest가 false이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData({ createdAt: null }), otherUserInfo })
+      );
+
+      expect(result.current.hasTradeRequest).toBe(false);
+    });
+
+    it('product가 null이면 hasTradeRequest가 false이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+      );
+
+      expect(result.current.hasTradeRequest).toBe(false);
+    });
+
+    it('roomData가 null이면 hasTradeRequest가 false이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: null, otherUserInfo })
+      );
+
+      expect(result.current.hasTradeRequest).toBe(false);
+    });
+  });
+
+  describe('shouldShowButtons', () => {
+    it('hasTradeRequest=true, isCompletable=true이면 shouldShowButtons가 true이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData({ isCompletable: true }), otherUserInfo })
+      );
+
+      expect(result.current.shouldShowButtons).toBe(true);
+    });
+
+    it('isCompletable=false이면 shouldShowButtons가 false이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData({ isCompletable: false }), otherUserInfo })
+      );
+
+      expect(result.current.shouldShowButtons).toBe(false);
+    });
+
+    it('createdAt이 null이면 shouldShowButtons가 false이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData({ createdAt: null }), otherUserInfo })
+      );
+
+      expect(result.current.shouldShowButtons).toBe(false);
+    });
+  });
+
+  describe('handleTradeAccept', () => {
+    it('성공 시 requestTrade를 호출하고 성공 Toast를 표시한다', async () => {
+      mockRequestTrade.mockResolvedValue({});
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleTradeAccept();
+      });
+
+      expect(mockRequestTrade).toHaveBeenCalledWith({ productId: 1, otherMemberId: 42 });
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', text1: '거래가 수락되었습니다!' })
+      );
+    });
+
+    it('실패 시 에러 Toast를 표시한다', async () => {
+      mockRequestTrade.mockRejectedValue(new Error('수락 실패'));
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleTradeAccept();
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', text1: '거래 수락 실패', text2: '수락 실패' })
+      );
+    });
+
+    it('otherUserInfo.id가 없으면 requestTrade를 호출하지 않는다', async () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo: { nickname: '상대방' } })
+      );
+
+      await act(async () => {
+        await result.current.handleTradeAccept();
+      });
+
+      expect(mockRequestTrade).not.toHaveBeenCalled();
+    });
+
+    it('productId가 없으면 requestTrade를 호출하지 않는다', async () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleTradeAccept();
+      });
+
+      expect(mockRequestTrade).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleReservation', () => {
+    it('성공 시 makeReservation을 호출하고 성공 Toast를 표시한다', async () => {
+      mockMakeReservation.mockResolvedValue({});
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleReservation();
+      });
+
+      expect(mockMakeReservation).toHaveBeenCalledWith({ productId: 1 });
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', text1: '예약이 완료되었습니다!' })
+      );
+    });
+
+    it('실패 시 에러 Toast를 표시한다', async () => {
+      mockMakeReservation.mockRejectedValue(new Error('예약 실패'));
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleReservation();
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', text1: '예약 실패' })
+      );
+    });
+
+    it('productId가 없으면 makeReservation을 호출하지 않는다', async () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleReservation();
+      });
+
+      expect(mockMakeReservation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCancelReservation', () => {
+    it('성공 시 cancelReservation을 호출하고 성공 Toast를 표시한다', async () => {
+      mockCancelReservation.mockResolvedValue({});
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleCancelReservation();
+      });
+
+      expect(mockCancelReservation).toHaveBeenCalledWith({ productId: 1 });
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'success', text1: '예약이 취소되었습니다!' })
+      );
+    });
+
+    it('실패 시 에러 Toast를 표시한다', async () => {
+      mockCancelReservation.mockRejectedValue(new Error('취소 실패'));
+
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleCancelReservation();
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', text1: '예약 취소 실패', text2: '취소 실패' })
+      );
+    });
+
+    it('productId가 없으면 cancelReservation을 호출하지 않는다', async () => {
+      const { result } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+      );
+
+      await act(async () => {
+        await result.current.handleCancelReservation();
+      });
+
+      expect(mockCancelReservation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/widget/post/model/__tests__/usePostAction.test.ts
+++ b/src/widget/post/model/__tests__/usePostAction.test.ts
@@ -128,6 +128,22 @@ describe('usePostAction', () => {
 
       expect(result.current.computedValues.canTrade).toBe(false);
     });
+
+    it('isCompletable=false이면 canTrade가 false이다', async () => {
+      setupMocks({ mode: 'RECEIVER', isCompletable: false, isCompleted: false });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.canTrade).toBe(false);
+    });
+
+    it('mode=GIVER이면 canTrade가 false이다', async () => {
+      setupMocks({ mode: 'GIVER', isCompletable: true, isCompleted: false });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.canTrade).toBe(false);
+    });
   });
 
   describe('modalHandlers', () => {
@@ -139,6 +155,16 @@ describe('usePostAction', () => {
 
       act(() => result.current.modalHandlers.closeReportModal());
       expect(result.current.isReportModalVisible).toBe(false);
+    });
+
+    it('openReviewModal / closeReviewModal이 isReviewModalVisible을 토글한다', () => {
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.modalHandlers.openReviewModal());
+      expect(result.current.isReviewModalVisible).toBe(true);
+
+      act(() => result.current.modalHandlers.closeReviewModal());
+      expect(result.current.isReviewModalVisible).toBe(false);
     });
 
     it('review prop이 있으면 isReviewModalVisible 초기값이 true이다', () => {
@@ -189,6 +215,78 @@ describe('usePostAction', () => {
       act(() => result.current.reviewHandlers.onContentsChange('리뷰 내용'));
       expect(result.current.reviewContents).toBe('리뷰 내용');
     });
+
+    it('onAnimationComplete이 reviewLight를 60으로, reviewContents를 빈 문자열로 초기화한다', () => {
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.reviewHandlers.onLightChange(90));
+      act(() => result.current.reviewHandlers.onContentsChange('내용'));
+      act(() => result.current.reviewHandlers.onAnimationComplete());
+
+      expect(result.current.reviewLight).toBe(60);
+      expect(result.current.reviewContents).toBe('');
+    });
+  });
+
+  describe('navigationHandlers', () => {
+    it('goToEdit를 호출해도 오류가 발생하지 않는다', () => {
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.navigationHandlers.goToEdit());
+    });
+
+    it('goToChat이 navigateToChat을 data.id로 호출한다', async () => {
+      const mockNavigateToChat = jest.fn().mockResolvedValue({});
+      mockUseChatEntry.mockReturnValue({ navigateToChat: mockNavigateToChat, isLoading: false });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      await act(async () => {
+        await result.current.navigationHandlers.goToChat();
+      });
+
+      expect(mockNavigateToChat).toHaveBeenCalledWith(1);
+    });
+
+    it('goToChat이 data가 없으면 navigateToChat을 호출하지 않는다', async () => {
+      const mockNavigateToChat = jest.fn();
+      mockUseChatEntry.mockReturnValue({ navigateToChat: mockNavigateToChat, isLoading: false });
+      mockUseGetItem.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      await act(async () => {
+        await result.current.navigationHandlers.goToChat();
+      });
+
+      expect(mockNavigateToChat).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('actionHandlers.onDelete', () => {
+    it('data가 있으면 onDelete 호출 시 오류가 없다', () => {
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.actionHandlers.onDelete());
+    });
+
+    it('data가 없으면 아무것도 하지 않는다', () => {
+      mockUseGetItem.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.actionHandlers.onDelete());
+    });
   });
 
   describe('actionHandlers.onRefresh', () => {
@@ -208,6 +306,28 @@ describe('usePostAction', () => {
       });
 
       expect(mockRefetch).toHaveBeenCalled();
+      expect(result.current.refreshing).toBe(false);
+    });
+
+    it('refetch가 실패해도 finally에서 refreshing이 false로 리셋된다', async () => {
+      const mockRefetch = jest.fn().mockRejectedValue(new Error('network error'));
+      mockUseGetItem.mockReturnValue({
+        data: makePostData(),
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      await act(async () => {
+        try {
+          await result.current.actionHandlers.onRefresh();
+        } catch {
+          // expected
+        }
+      });
+
       expect(result.current.refreshing).toBe(false);
     });
   });

--- a/src/widget/post/model/__tests__/usePostAction.test.ts
+++ b/src/widget/post/model/__tests__/usePostAction.test.ts
@@ -1,0 +1,214 @@
+import { act, waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { usePostAction } from '../usePostAction';
+import { useGetItem } from '~/entity/post/model/useGetItem';
+import { useDeletePost } from '~/entity/post';
+import { useTradeRequest } from '~/entity/post/hooks/useTradeRequest';
+import { useChatEntry } from '~/shared/lib/useChatEntry';
+import { checkIsMyPost } from '~/shared/lib/userUtils';
+import { createReview } from '~/entity/post/api/createReview';
+import Toast from 'react-native-toast-message';
+
+jest.mock('~/entity/post/model/useGetItem', () => ({ useGetItem: jest.fn() }));
+jest.mock('~/entity/post', () => ({ useDeletePost: jest.fn() }));
+jest.mock('~/entity/post/hooks/useTradeRequest', () => ({ useTradeRequest: jest.fn() }));
+jest.mock('~/shared/lib/useChatEntry', () => ({ useChatEntry: jest.fn() }));
+jest.mock('~/shared/lib/userUtils', () => ({ checkIsMyPost: jest.fn() }));
+jest.mock('~/entity/post/api/createReview', () => ({ createReview: jest.fn() }));
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('react-native-toast-message', () => ({
+  __esModule: true,
+  default: { show: jest.fn() },
+}));
+
+const mockUseGetItem = useGetItem as jest.Mock;
+const mockUseDeletePost = useDeletePost as jest.Mock;
+const mockUseTradeRequest = useTradeRequest as jest.Mock;
+const mockUseChatEntry = useChatEntry as jest.Mock;
+const mockCheckIsMyPost = checkIsMyPost as jest.Mock;
+const mockCreateReview = createReview as jest.Mock;
+
+const makePostData = (overrides = {}) => ({
+  id: 1,
+  title: '테스트 게시글',
+  content: '내용',
+  type: 'OBJECT',
+  mode: 'GIVER',
+  isCompletable: true,
+  isCompleted: false,
+  member: { memberId: 42 },
+  ...overrides,
+});
+
+const setupMocks = (dataOverrides = {}) => {
+  mockUseGetItem.mockReturnValue({
+    data: makePostData(dataOverrides),
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  });
+  mockUseDeletePost.mockReturnValue({ deletePost: jest.fn(), isLoading: false });
+  mockUseTradeRequest.mockReturnValue({
+    handleTradeRequest: jest.fn(),
+    isLoading: false,
+  });
+  mockUseChatEntry.mockReturnValue({ navigateToChat: jest.fn(), isLoading: false });
+  mockCheckIsMyPost.mockResolvedValue(false);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMocks();
+});
+
+describe('usePostAction', () => {
+  describe('초기 상태', () => {
+    it('isMyPost 초기값이 false이다', async () => {
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      await waitFor(() => expect(mockCheckIsMyPost).toHaveBeenCalled());
+      expect(result.current.isMyPost).toBe(false);
+    });
+
+    it('data가 있으면 checkIsMyPost를 호출한다', async () => {
+      mockCheckIsMyPost.mockResolvedValue(true);
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      await waitFor(() => expect(result.current.isMyPost).toBe(true));
+      expect(mockCheckIsMyPost).toHaveBeenCalledWith(42);
+    });
+  });
+
+  describe('computedValues', () => {
+    it('mode=RECEIVER, type=OBJECT이면 headerTitle이 "필요해요"이다', async () => {
+      setupMocks({ mode: 'RECEIVER', type: 'OBJECT' });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.headerTitle).toBe('필요해요');
+    });
+
+    it('mode=RECEIVER, type=SERVICE이면 headerTitle이 "해주세요"이다', async () => {
+      setupMocks({ mode: 'RECEIVER', type: 'SERVICE' });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.headerTitle).toBe('해주세요');
+    });
+
+    it('mode=GIVER, type=OBJECT이면 headerTitle이 "팔아요"이다', async () => {
+      setupMocks({ mode: 'GIVER', type: 'OBJECT' });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.headerTitle).toBe('팔아요');
+    });
+
+    it('mode=GIVER, type=SERVICE이면 headerTitle이 "할 수 있어요"이다', async () => {
+      setupMocks({ mode: 'GIVER', type: 'SERVICE' });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.headerTitle).toBe('할 수 있어요');
+    });
+
+    it('mode=RECEIVER, isCompletable=true, isCompleted=false이면 canTrade가 true이다', async () => {
+      setupMocks({ mode: 'RECEIVER', isCompletable: true, isCompleted: false });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.canTrade).toBe(true);
+    });
+
+    it('isCompleted=true이면 canTrade가 false이다', async () => {
+      setupMocks({ mode: 'RECEIVER', isCompletable: true, isCompleted: true });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      expect(result.current.computedValues.canTrade).toBe(false);
+    });
+  });
+
+  describe('modalHandlers', () => {
+    it('openReportModal / closeReportModal이 isReportModalVisible을 토글한다', () => {
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.modalHandlers.openReportModal());
+      expect(result.current.isReportModalVisible).toBe(true);
+
+      act(() => result.current.modalHandlers.closeReportModal());
+      expect(result.current.isReportModalVisible).toBe(false);
+    });
+
+    it('review prop이 있으면 isReviewModalVisible 초기값이 true이다', () => {
+      const { result } = renderHookWithProviders(() =>
+        usePostAction({ id: '1', review: 'some-review' })
+      );
+
+      expect(result.current.isReviewModalVisible).toBe(true);
+    });
+  });
+
+  describe('reviewHandlers', () => {
+    it('onSubmit 성공 시 성공 Toast를 표시하고 모달을 닫는다', async () => {
+      mockCreateReview.mockResolvedValue({});
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.modalHandlers.openReviewModal());
+
+      await act(async () => {
+        await result.current.reviewHandlers.onSubmit(80, '좋았어요');
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+      expect(result.current.isReviewModalVisible).toBe(false);
+    });
+
+    it('onSubmit 실패 시 에러 Toast를 표시한다', async () => {
+      mockCreateReview.mockRejectedValue(new Error('리뷰 실패'));
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      await act(async () => {
+        await result.current.reviewHandlers.onSubmit(80, '좋았어요');
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error', text1: '리뷰 작성 실패' })
+      );
+    });
+
+    it('onLightChange / onContentsChange로 값을 업데이트한다', () => {
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      act(() => result.current.reviewHandlers.onLightChange(90));
+      expect(result.current.reviewLight).toBe(90);
+
+      act(() => result.current.reviewHandlers.onContentsChange('리뷰 내용'));
+      expect(result.current.reviewContents).toBe('리뷰 내용');
+    });
+  });
+
+  describe('actionHandlers.onRefresh', () => {
+    it('refetch를 호출하고 refreshing 상태를 처리한다', async () => {
+      const mockRefetch = jest.fn().mockResolvedValue({});
+      mockUseGetItem.mockReturnValue({
+        data: makePostData(),
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      const { result } = renderHookWithProviders(() => usePostAction({ id: '1' }));
+
+      await act(async () => {
+        await result.current.actionHandlers.onRefresh();
+      });
+
+      expect(mockRefetch).toHaveBeenCalled();
+      expect(result.current.refreshing).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## 작업 내용

- shared/api: getPosts, uploadImage
- shared/model: useGetPosts, useUploadImage
- widget/chat/model: useChatInput, useChatMessages, useChatUIState, useChatAction, useTradeHandlers
- widget/post: usePostAction
- widget/cancelTrade: cancelTrade, useCancelTrade
- view/profile: API 7개 + model hook 7개
- view/cancelTrade: getReview, useGetReview
- view/reviews: getReceiveReview, getTossReview

## 기타
- immer ESM 빌드 대응을 위해 jest.config.js transformIgnorePatterns에 immer 추가