### PR TITLE
fix: ok check first

### DIFF
--- a/src/entity/auth/api/__tests__/sendSms.test.ts
+++ b/src/entity/auth/api/__tests__/sendSms.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 describe('sendSms', () => {
   it('정상적인 전화번호로 SMS 전송에 성공한다', async () => {
     mockFetch({ message: 'success' });
-    expect(await sendSms('01012345678')).toEqual({ message: 'success' });
+    await expect(sendSms('01012345678')).resolves.not.toThrow();
   });
 
   it('올바른 엔드포인트와 바디로 요청을 보낸다', async () => {

--- a/src/entity/auth/api/sendSms.ts
+++ b/src/entity/auth/api/sendSms.ts
@@ -11,22 +11,15 @@ export const sendSms = async (phoneNumber: string) => {
       body: JSON.stringify({ phoneNumber }),
     });
 
-    const responseText = await response.text();
-
-    let data;
-    try {
-      data = JSON.parse(responseText);
-    } catch (parseError) {
-      console.error(parseError, responseText);
-      throw new Error(responseText.substring(0, 100));
-    }
-
     if (!response.ok) {
-      const errorMessage = data.message || `HTTP ${response.status}: ${response.statusText}`;
+      const responseText = await response.text();
+      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      try {
+        const data = JSON.parse(responseText);
+        if (data.message) errorMessage = data.message;
+      } catch {}
       throw new Error(errorMessage);
     }
-
-    return data;
   } catch (error) {
     console.error(error);
     throw new Error(getErrorMessage(error));


### PR DESCRIPTION
response.ok 체크를 먼저 수행해서 성공(200)이면 body 파싱 없이 바로 return칩니다.
실패 시에만 body를 읽어서 에러 메시지를 추출을 시도해서 빈 body나 non-JSON body여도 에러가 발생하지 않아요.