### PR TITLE
 feat: 이미지 첨부 시 갤러리/카메라 선택 옵션 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Update npm
+        run: npm install -g npm@11
+
       - name: Install dependencies
         run: npm ci
 
@@ -42,6 +45,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Update npm
+        run: npm install -g npm@11
+
       - name: Report unit test coverage
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
@@ -62,6 +74,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+
+      - name: Update npm
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci

--- a/app.json
+++ b/app.json
@@ -51,6 +51,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSPhotoLibraryUsageDescription": "거래 게시글 업로드 및 채팅에 사용할 이미지 업로드를 위해 저장공간에 접근합니다.",
+        "NSCameraUsageDescription": "거래 게시글 업로드 및 채팅에 사용할 사진을 즉시 촬영하기 위해 카메라에 접근합니다.",
         "NSFaceIDUsageDescription": "생체 인증으로 로그인하기 위해 Face ID를 사용합니다."
       }
     },

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["detox", "jest", "node"]
+  }
+}

--- a/src/shared/ui/ImageUploader/__tests__/ImageUploader.test.tsx
+++ b/src/shared/ui/ImageUploader/__tests__/ImageUploader.test.tsx
@@ -1,0 +1,292 @@
+import React, { useState } from 'react';
+import { fireEvent, waitFor, act } from '@testing-library/react-native';
+import { ActionSheetIOS, TouchableOpacity } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { renderWithProviders } from '~/test-utils';
+import ImageUploader from '../index';
+import { useUploadImage } from '@/shared/model/useUploadImage';
+
+jest.mock('@/shared/model/useUploadImage', () => ({
+  useUploadImage: jest.fn(),
+}));
+
+jest.mock('expo-image-picker', () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  requestCameraPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+  launchCameraAsync: jest.fn(),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  show: jest.fn(),
+}));
+
+const mockUseUploadImage = useUploadImage as jest.Mock;
+const mockRequestGalleryPermission = ImagePicker.requestMediaLibraryPermissionsAsync as jest.Mock;
+const mockRequestCameraPermission = ImagePicker.requestCameraPermissionsAsync as jest.Mock;
+const mockLaunchGallery = ImagePicker.launchImageLibraryAsync as jest.Mock;
+const mockLaunchCamera = ImagePicker.launchCameraAsync as jest.Mock;
+
+const setupUploadMock = (mutateAsync = jest.fn()) => {
+  mockUseUploadImage.mockReturnValue({ mutateAsync });
+  return mutateAsync;
+};
+
+// ActionSheet를 갤러리(1) 선택으로 고정
+const mockActionSheetGallery = () =>
+  jest
+    .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+    .mockImplementation((_opts: any, cb: any) => cb(1));
+
+// ActionSheet를 카메라(2) 선택으로 고정
+const mockActionSheetCamera = () =>
+  jest
+    .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+    .mockImplementation((_opts: any, cb: any) => cb(2));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupUploadMock();
+  mockActionSheetGallery();
+  // 기본값: 권한 거부 (ActionSheet 콜백 후 비동기 흐름이 조용히 종료되도록)
+  mockRequestGalleryPermission.mockResolvedValue({ granted: false });
+  mockRequestCameraPermission.mockResolvedValue({ granted: false });
+});
+
+// images 상태를 직접 관리하는 래퍼 (removeImageByUri가 images prop에 의존하므로 필요)
+const StatefulImageUploader = ({
+  onImagesChange,
+  onImageIdsChange,
+  onUploadStateChange,
+}: {
+  onImagesChange?: jest.Mock;
+  onImageIdsChange?: jest.Mock;
+  onUploadStateChange?: jest.Mock;
+}) => {
+  const [images, setImages] = useState<string[]>([]);
+  return (
+    <ImageUploader
+      images={images}
+      onImagesChange={(newImages) => {
+        setImages(newImages);
+        onImagesChange?.(newImages);
+      }}
+      onImageIdsChange={onImageIdsChange}
+      onUploadStateChange={onUploadStateChange}
+    />
+  );
+};
+
+// 버튼 쿼리 헬퍼 (TouchableOpacity accessibilityRole 미설정 환경 대응)
+const getButtons = (container: ReturnType<typeof renderWithProviders>) =>
+  container.UNSAFE_getAllByType(TouchableOpacity);
+
+describe('ImageUploader', () => {
+  describe('렌더링', () => {
+    it('title을 렌더링한다', () => {
+      const { getByText } = renderWithProviders(<ImageUploader title="사진 업로드" />);
+      expect(getByText('사진 업로드')).toBeTruthy();
+    });
+
+    it('기본 title은 "사진첨부"이다', () => {
+      const { getByText } = renderWithProviders(<ImageUploader />);
+      expect(getByText('사진첨부')).toBeTruthy();
+    });
+
+    it('images prop으로 이미지 2개와 첨부 버튼을 렌더링한다', () => {
+      const container = renderWithProviders(
+        <ImageUploader images={['file://a.jpg', 'file://b.jpg']} />
+      );
+      // 이미지 버튼 2개 + 첨부 버튼 1개
+      expect(getButtons(container)).toHaveLength(3);
+    });
+
+    it('readonly=true이면 첨부 버튼이 렌더링되지 않는다', () => {
+      const container = renderWithProviders(<ImageUploader images={['file://a.jpg']} readonly />);
+      // 이미지 버튼 1개만 (disabled), 첨부 버튼 없음
+      expect(getButtons(container)).toHaveLength(1);
+    });
+
+    it('maxImages 도달 시 첨부 버튼이 렌더링되지 않는다', () => {
+      const container = renderWithProviders(
+        <ImageUploader images={['file://a.jpg', 'file://b.jpg']} maxImages={2} />
+      );
+      expect(getButtons(container)).toHaveLength(2);
+    });
+  });
+
+  describe('pickImage', () => {
+    it('첨부 버튼 탭 시 ActionSheetIOS가 열린다', () => {
+      const container = renderWithProviders(<ImageUploader />);
+      fireEvent.press(getButtons(container)[0]);
+
+      expect(ActionSheetIOS.showActionSheetWithOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ options: ['취소', '갤러리에서 선택', '카메라로 촬영'] }),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('갤러리 선택', () => {
+    it('권한 거부 시 Toast 에러를 표시한다', async () => {
+      const Toast = require('react-native-toast-message');
+      mockRequestGalleryPermission.mockResolvedValue({ granted: false });
+
+      const container = renderWithProviders(<ImageUploader />);
+      fireEvent.press(getButtons(container)[0]);
+
+      await waitFor(() => {
+        expect(Toast.show).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'error', text2: '사진 접근 권한이 필요합니다.' })
+        );
+      });
+    });
+
+    it('선택 취소 시 onImagesChange가 호출되지 않는다', async () => {
+      mockRequestGalleryPermission.mockResolvedValue({ granted: true });
+      mockLaunchGallery.mockResolvedValue({ canceled: true, assets: [] });
+
+      const onImagesChange = jest.fn();
+      const container = renderWithProviders(<ImageUploader onImagesChange={onImagesChange} />);
+      fireEvent.press(getButtons(container)[0]);
+
+      await waitFor(() => expect(mockLaunchGallery).toHaveBeenCalled());
+      expect(onImagesChange).not.toHaveBeenCalled();
+    });
+
+    it('선택 성공 시 업로드 후 onImagesChange와 onImageIdsChange가 호출된다', async () => {
+      setupUploadMock(
+        jest.fn().mockResolvedValue({ imageId: 10, imageUrl: 'https://example.com/img.jpg' })
+      );
+      mockRequestGalleryPermission.mockResolvedValue({ granted: true });
+      mockLaunchGallery.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file://photo.jpg' }],
+      });
+
+      const onImagesChange = jest.fn();
+      const onImageIdsChange = jest.fn();
+      const container = renderWithProviders(
+        <ImageUploader onImagesChange={onImagesChange} onImageIdsChange={onImageIdsChange} />
+      );
+
+      fireEvent.press(getButtons(container)[0]);
+
+      await waitFor(() => expect(onImageIdsChange).toHaveBeenCalledWith([10]));
+      expect(onImagesChange).toHaveBeenCalledWith(['file://photo.jpg']);
+    });
+  });
+
+  describe('카메라 촬영', () => {
+    beforeEach(() => {
+      mockActionSheetCamera();
+    });
+
+    it('권한 거부 시 Toast 에러를 표시한다', async () => {
+      const Toast = require('react-native-toast-message');
+      mockRequestCameraPermission.mockResolvedValue({ granted: false });
+
+      const container = renderWithProviders(<ImageUploader />);
+      fireEvent.press(getButtons(container)[0]);
+
+      await waitFor(() => {
+        expect(Toast.show).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'error', text2: '카메라 접근 권한이 필요합니다.' })
+        );
+      });
+    });
+
+    it('촬영 성공 시 업로드 후 onImageIdsChange가 호출된다', async () => {
+      setupUploadMock(
+        jest.fn().mockResolvedValue({ imageId: 20, imageUrl: 'https://example.com/cam.jpg' })
+      );
+      mockRequestCameraPermission.mockResolvedValue({ granted: true });
+      mockLaunchCamera.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file://camera.jpg' }],
+      });
+
+      const onImageIdsChange = jest.fn();
+      const container = renderWithProviders(<ImageUploader onImageIdsChange={onImageIdsChange} />);
+
+      fireEvent.press(getButtons(container)[0]);
+
+      await waitFor(() => expect(onImageIdsChange).toHaveBeenCalledWith([20]));
+    });
+  });
+
+  describe('업로드 실패', () => {
+    it('업로드 실패 시 hasFailedImages=true로 onUploadStateChange가 호출된다', async () => {
+      setupUploadMock(jest.fn().mockRejectedValue(new Error('upload error')));
+      mockRequestGalleryPermission.mockResolvedValue({ granted: true });
+      mockLaunchGallery.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file://photo.jpg' }],
+      });
+
+      const onUploadStateChange = jest.fn();
+      const container = renderWithProviders(
+        <StatefulImageUploader onUploadStateChange={onUploadStateChange} />
+      );
+
+      fireEvent.press(getButtons(container)[0]);
+
+      await waitFor(() =>
+        expect(onUploadStateChange).toHaveBeenCalledWith(
+          expect.objectContaining({ hasFailedImages: true, hasUploadingImages: false })
+        )
+      );
+    });
+  });
+
+  describe('이미지 제거', () => {
+    it('이미지 탭 시 onImagesChange가 빈 배열로 호출된다', () => {
+      const onImagesChange = jest.fn();
+      const container = renderWithProviders(
+        <ImageUploader images={['file://a.jpg']} onImagesChange={onImagesChange} />
+      );
+
+      // 첫 번째 버튼은 이미지 버튼
+      fireEvent.press(getButtons(container)[0]);
+
+      expect(onImagesChange).toHaveBeenCalledWith([]);
+    });
+
+    it('readonly=true이면 이미지 탭해도 onImagesChange가 호출되지 않는다', () => {
+      const onImagesChange = jest.fn();
+      const container = renderWithProviders(
+        <ImageUploader images={['file://a.jpg']} readonly onImagesChange={onImagesChange} />
+      );
+
+      fireEvent.press(getButtons(container)[0]);
+
+      expect(onImagesChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onUploadStateChange', () => {
+    it('업로드 완료 후 uploadedCount=1로 onUploadStateChange가 호출된다', async () => {
+      setupUploadMock(
+        jest.fn().mockResolvedValue({ imageId: 1, imageUrl: 'https://example.com/img.jpg' })
+      );
+      mockRequestGalleryPermission.mockResolvedValue({ granted: true });
+      mockLaunchGallery.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file://photo.jpg' }],
+      });
+
+      const onUploadStateChange = jest.fn();
+      const container = renderWithProviders(
+        <ImageUploader onUploadStateChange={onUploadStateChange} />
+      );
+
+      fireEvent.press(getButtons(container)[0]);
+
+      await waitFor(() =>
+        expect(onUploadStateChange).toHaveBeenCalledWith(
+          expect.objectContaining({ uploadedCount: 1, hasUploadingImages: false })
+        )
+      );
+    });
+  });
+});

--- a/src/shared/ui/ImageUploader/index.tsx
+++ b/src/shared/ui/ImageUploader/index.tsx
@@ -1,4 +1,13 @@
-import { View, TouchableOpacity, Image, Text, ActivityIndicator } from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+  Image,
+  Text,
+  ActivityIndicator,
+  ActionSheetIOS,
+  Alert,
+  Platform,
+} from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 import * as ImagePicker from 'expo-image-picker';
 import { memo, useState, useCallback, useMemo, useEffect } from 'react';
@@ -86,16 +95,49 @@ const ImageUploader = ({
     [images, imageStatuses, onImagesChange, onImageIdsChange]
   );
 
-  const pickImage = useCallback(async () => {
-    if (readonly || images.length >= maxImages) return;
+  const handleImageSelected = useCallback(
+    async (uri: string) => {
+      onImagesChange?.([...images, uri]);
 
+      const newStatus: ImageStatus = { uri, status: 'uploading' };
+      setImageStatuses((prev) => [...prev, newStatus]);
+
+      try {
+        const uploadedImage = await uploadImageMutation.mutateAsync(uri);
+        updateImageStatus(uri, { status: 'uploaded', imageData: uploadedImage });
+
+        const allUploadedStatuses = imageStatuses.filter(
+          (s) => s.status === 'uploaded' && s.imageData
+        );
+        const imageIds = [
+          ...allUploadedStatuses,
+          { ...newStatus, status: 'uploaded' as const, imageData: uploadedImage },
+        ].map((s) => s.imageData!.imageId);
+        onImageIdsChange?.(imageIds);
+      } catch (error) {
+        console.error(error);
+        updateImageStatus(uri, {
+          status: 'failed',
+          error: error instanceof Error ? error : new Error('업로드 실패'),
+        });
+        setTimeout(() => removeImageByUri(uri), 1500);
+      }
+    },
+    [
+      images,
+      onImagesChange,
+      imageStatuses,
+      uploadImageMutation,
+      updateImageStatus,
+      removeImageByUri,
+      onImageIdsChange,
+    ]
+  );
+
+  const pickFromGallery = useCallback(async () => {
     const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permissionResult.granted) {
-      Toast.show({
-        type: 'error',
-        text1: '권한 필요',
-        text2: '차일 접근 권한이 필요합니다.',
-      });
+      Toast.show({ type: 'error', text1: '권한 필요', text2: '사진 접근 권한이 필요합니다.' });
       return;
     }
 
@@ -107,59 +149,53 @@ const ImageUploader = ({
       });
 
       if (!result.canceled && result.assets && result.assets.length > 0) {
-        const newImageUri = result.assets[0].uri;
-        const newImages = [...images, newImageUri];
-        onImagesChange?.(newImages);
-
-        const newStatus: ImageStatus = {
-          uri: newImageUri,
-          status: 'uploading',
-        };
-        setImageStatuses((prev) => [...prev, newStatus]);
-
-        try {
-          const uploadedImage = await uploadImageMutation.mutateAsync(newImageUri);
-
-          updateImageStatus(newImageUri, {
-            status: 'uploaded',
-            imageData: uploadedImage,
-          });
-
-          const allUploadedStatuses = imageStatuses.filter(
-            (s) => s.status === 'uploaded' && s.imageData
-          );
-          const updatedStatuses = [
-            ...allUploadedStatuses,
-            { ...newStatus, status: 'uploaded' as const, imageData: uploadedImage },
-          ];
-          const imageIds = updatedStatuses.map((status) => status.imageData!.imageId);
-          onImageIdsChange?.(imageIds);
-        } catch (error) {
-          console.error(error);
-          updateImageStatus(newImageUri, {
-            status: 'failed',
-            error: error instanceof Error ? error : new Error('업로드 실패'),
-          });
-
-          setTimeout(() => {
-            removeImageByUri(newImageUri);
-          }, 1500);
-        }
+        await handleImageSelected(result.assets[0].uri);
       }
     } catch (error) {
       console.error('이미지 선택 중 오류:', error);
     }
-  }, [
-    images,
-    maxImages,
-    readonly,
-    onImagesChange,
-    imageStatuses,
-    uploadImageMutation,
-    updateImageStatus,
-    removeImageByUri,
-    onImageIdsChange,
-  ]);
+  }, [handleImageSelected]);
+
+  const pickFromCamera = useCallback(async () => {
+    const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
+    if (!permissionResult.granted) {
+      Toast.show({ type: 'error', text1: '권한 필요', text2: '카메라 접근 권한이 필요합니다.' });
+      return;
+    }
+
+    try {
+      const result = await ImagePicker.launchCameraAsync({
+        mediaTypes: ['images'],
+        quality: 0.8,
+      });
+
+      if (!result.canceled && result.assets && result.assets.length > 0) {
+        await handleImageSelected(result.assets[0].uri);
+      }
+    } catch (error) {
+      console.error('카메라 촬영 중 오류:', error);
+    }
+  }, [handleImageSelected]);
+
+  const pickImage = useCallback(() => {
+    if (readonly || images.length >= maxImages) return;
+
+    if (Platform.OS === 'ios') {
+      ActionSheetIOS.showActionSheetWithOptions(
+        { options: ['취소', '갤러리에서 선택', '카메라로 촬영'], cancelButtonIndex: 0 },
+        (buttonIndex) => {
+          if (buttonIndex === 1) pickFromGallery();
+          if (buttonIndex === 2) pickFromCamera();
+        }
+      );
+    } else {
+      Alert.alert('사진 선택', undefined, [
+        { text: '취소', style: 'cancel' },
+        { text: '갤러리에서 선택', onPress: pickFromGallery },
+        { text: '카메라로 촬영', onPress: pickFromCamera },
+      ]);
+    }
+  }, [readonly, images.length, maxImages, pickFromGallery, pickFromCamera]);
 
   const removeImage = useCallback(
     (index: number) => {

--- a/src/shared/ui/ImageUploader/index.tsx
+++ b/src/shared/ui/ImageUploader/index.tsx
@@ -70,6 +70,13 @@ const ImageUploader = ({
     onUploadStateChange?.(uploadState);
   }, [uploadState, onUploadStateChange]);
 
+  useEffect(() => {
+    const uploadedIds = imageStatuses
+      .filter((s) => s.status === 'uploaded' && s.imageData)
+      .map((s) => s.imageData!.imageId);
+    onImageIdsChange?.(uploadedIds);
+  }, [imageStatuses, onImageIdsChange]);
+
   const updateImageStatus = useCallback((uri: string, status: Partial<ImageStatus>) => {
     setImageStatuses((prev) =>
       prev.map((item) => (item.uri === uri ? { ...item, ...status } : item))
@@ -85,14 +92,8 @@ const ImageUploader = ({
       onImagesChange?.(newImages);
 
       setImageStatuses((prev) => prev.filter((item) => item.uri !== uri));
-
-      const uploadedStatuses = imageStatuses.filter(
-        (status) => status.uri !== uri && status.status === 'uploaded' && status.imageData
-      );
-      const imageIds = uploadedStatuses.map((status) => status.imageData!.imageId);
-      onImageIdsChange?.(imageIds);
     },
-    [images, imageStatuses, onImagesChange, onImageIdsChange]
+    [images, onImagesChange]
   );
 
   const handleImageSelected = useCallback(
@@ -105,15 +106,6 @@ const ImageUploader = ({
       try {
         const uploadedImage = await uploadImageMutation.mutateAsync(uri);
         updateImageStatus(uri, { status: 'uploaded', imageData: uploadedImage });
-
-        const allUploadedStatuses = imageStatuses.filter(
-          (s) => s.status === 'uploaded' && s.imageData
-        );
-        const imageIds = [
-          ...allUploadedStatuses,
-          { ...newStatus, status: 'uploaded' as const, imageData: uploadedImage },
-        ].map((s) => s.imageData!.imageId);
-        onImageIdsChange?.(imageIds);
       } catch (error) {
         console.error(error);
         updateImageStatus(uri, {
@@ -123,15 +115,7 @@ const ImageUploader = ({
         setTimeout(() => removeImageByUri(uri), 1500);
       }
     },
-    [
-      images,
-      onImagesChange,
-      imageStatuses,
-      uploadImageMutation,
-      updateImageStatus,
-      removeImageByUri,
-      onImageIdsChange,
-    ]
+    [images, onImagesChange, uploadImageMutation, updateImageStatus, removeImageByUri]
   );
 
   const pickFromGallery = useCallback(async () => {

--- a/src/widget/chat/model/__tests__/useChatInput.test.ts
+++ b/src/widget/chat/model/__tests__/useChatInput.test.ts
@@ -1,4 +1,5 @@
 import { act } from '@testing-library/react-native';
+import { ActionSheetIOS } from 'react-native';
 import { renderHookWithProviders } from '~/test-utils';
 import { useChatInput } from '../useChatInput';
 
@@ -26,6 +27,11 @@ const setupUploadMock = (mutateAsync = jest.fn()) => {
 beforeEach(() => {
   jest.clearAllMocks();
   setupUploadMock();
+  jest
+    .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+    .mockImplementation((_options, callback) => {
+      callback(1); // '갤러리에서 선택' 시뮬레이션
+    });
 });
 
 describe('useChatInput', () => {

--- a/src/widget/chat/model/useChatInput.ts
+++ b/src/widget/chat/model/useChatInput.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { Alert } from 'react-native';
+import { Alert, ActionSheetIOS, Platform } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useUploadImage } from '@/shared/model/useUploadImage';
 
@@ -32,36 +32,6 @@ export const useChatInput = ({ onSendMessage, disabled = false }: UseChatInputPr
     setTextMessage(text);
   }, []);
 
-  const requestPermission = useCallback(async (): Promise<boolean> => {
-    const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!permissionResult.granted) {
-      Alert.alert('권한 필요', '사진첨부를 위해 사진첩 접근 권한이 필요합니다.');
-      return false;
-    }
-    return true;
-  }, []);
-
-  const selectImage = useCallback(async (): Promise<ImagePicker.ImagePickerAsset | null> => {
-    try {
-      const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ['images'],
-        allowsMultipleSelection: false,
-        quality: 0.8,
-        allowsEditing: true,
-        aspect: [1, 1],
-      });
-
-      if (!result.canceled && result.assets && result.assets.length > 0) {
-        return result.assets[0];
-      }
-      return null;
-    } catch (error) {
-      console.error(error);
-      Alert.alert('오류', '이미지 선택 중 오류가 발생했습니다.');
-      return null;
-    }
-  }, []);
-
   const uploadImage = useCallback(
     async (imageUri: string) => {
       try {
@@ -75,31 +45,80 @@ export const useChatInput = ({ onSendMessage, disabled = false }: UseChatInputPr
     [uploadImageMutation]
   );
 
-  const handleImagePicker = useCallback(async () => {
+  const pickAndUpload = useCallback(
+    async (launchFn: () => Promise<ImagePicker.ImagePickerResult>) => {
+      setIsUploading(true);
+      try {
+        const result = await launchFn();
+        if (result.canceled || !result.assets?.length) return;
+
+        const asset = result.assets[0];
+        const uploadedImage = await uploadImage(asset.uri);
+        setSelectedImages((prev) => [
+          ...prev,
+          { imageId: uploadedImage.imageId, imageUrl: uploadedImage.imageUrl, localUri: asset.uri },
+        ]);
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [uploadImage]
+  );
+
+  const pickFromGallery = useCallback(async () => {
+    const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permissionResult.granted) {
+      Alert.alert('권한 필요', '사진첨부를 위해 사진첩 접근 권한이 필요합니다.');
+      return;
+    }
+    await pickAndUpload(() =>
+      ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        allowsMultipleSelection: false,
+        quality: 0.8,
+        allowsEditing: true,
+        aspect: [1, 1],
+      })
+    );
+  }, [pickAndUpload]);
+
+  const pickFromCamera = useCallback(async () => {
+    const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
+    if (!permissionResult.granted) {
+      Alert.alert('권한 필요', '카메라 사용을 위해 카메라 접근 권한이 필요합니다.');
+      return;
+    }
+    await pickAndUpload(() =>
+      ImagePicker.launchCameraAsync({
+        mediaTypes: ['images'],
+        quality: 0.8,
+        allowsEditing: true,
+        aspect: [1, 1],
+      })
+    );
+  }, [pickAndUpload]);
+
+  const handleImagePicker = useCallback(() => {
     if (disabled || isUploading || selectedImages.length >= 5) return;
 
-    setIsUploading(true);
-
-    try {
-      const hasPermission = await requestPermission();
-      if (!hasPermission) return;
-
-      const selectedImage = await selectImage();
-      if (!selectedImage) return;
-
-      const uploadedImage = await uploadImage(selectedImage.uri);
-
-      const newImagePreview: ImagePreview = {
-        imageId: uploadedImage.imageId,
-        imageUrl: uploadedImage.imageUrl,
-        localUri: selectedImage.uri,
-      };
-
-      setSelectedImages((prev) => [...prev, newImagePreview]);
-    } finally {
-      setIsUploading(false);
+    if (Platform.OS === 'ios') {
+      ActionSheetIOS.showActionSheetWithOptions(
+        { options: ['취소', '갤러리에서 선택', '카메라로 촬영'], cancelButtonIndex: 0 },
+        (buttonIndex) => {
+          if (buttonIndex === 1) pickFromGallery();
+          if (buttonIndex === 2) pickFromCamera();
+        }
+      );
+    } else {
+      Alert.alert('사진 선택', undefined, [
+        { text: '취소', style: 'cancel' },
+        { text: '갤러리에서 선택', onPress: pickFromGallery },
+        { text: '카메라로 촬영', onPress: pickFromCamera },
+      ]);
     }
-  }, [disabled, isUploading, selectedImages.length, requestPermission, selectImage, uploadImage]);
+  }, [disabled, isUploading, selectedImages.length, pickFromGallery, pickFromCamera]);
 
   const removeImage = useCallback((imageId: number) => {
     setSelectedImages((prev) => prev.filter((img) => img.imageId !== imageId));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
+    "types": ["jest", "node"],
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,15 +4,13 @@
     "strict": true,
     "jsx": "react-jsx",
     "types": ["jest", "node"],
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@/app/*": ["src/app/*"],
-      "@/shared/*": ["src/shared/*"],
-      "@/entity/*": ["src/entity/*"],
-      "@/view/*": ["src/view/*"],
-      "@/widget/*": ["src/widget/*"]
+      "~/*": ["./src/*"],
+      "@/app/*": ["./src/app/*"],
+      "@/shared/*": ["./src/shared/*"],
+      "@/entity/*": ["./src/entity/*"],
+      "@/view/*": ["./src/view/*"],
+      "@/widget/*": ["./src/widget/*"]
     }
   }
 }


### PR DESCRIPTION
## issue 태그
#273

## Summary

  - 이미지 첨부 버튼 탭 시 갤러리 직접 실행 대신 선택 sheet를 먼저 노출하여 카메라 촬영도 지원
    - iOS: `ActionSheetIOS`로 "갤러리에서 선택" / "카메라로 촬영" / "취소" 제공
    - Android: `Alert.alert`로 동일 옵션 제공
  - `ImageUploader`와 `useChatInput` 양쪽 모두 적용하여 채팅·게시물 이미지 첨부 일관성 확보
  - `useChatInput`의 이미지 선택·업로드 로직을 `pickAndUpload` 공통 헬퍼로 추출해 중복 제거
  - iOS 카메라 권한 설명 문구(`NSCameraUsageDescription`) `app.json`에 추가