### PR TITLE
chore: Sentry 모니터링 강화

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { Stack } from 'expo-router';
+import { Stack, usePathname } from 'expo-router';
 import { AppState, View } from 'react-native';
 import { useEffect } from 'react';
 import { saveE2ECoverage } from '@/shared/lib/e2eCoverage';
@@ -14,13 +14,27 @@ import { NoNetworkOverlay } from '@/shared/ui/NoNetworkOverlay';
 export default function RootLayout() {
   const fontsLoaded = useCustomFonts();
   const isConnected = useNetworkStatus();
+  const pathname = usePathname();
 
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
       if (state === 'background') saveE2ECoverage();
+      SentryRN.addBreadcrumb({
+        category: 'app.lifecycle',
+        message: `App state changed to ${state}`,
+        level: 'info',
+      });
     });
     return () => sub.remove();
   }, []);
+
+  useEffect(() => {
+    SentryRN.addBreadcrumb({
+      category: 'navigation',
+      message: `Navigated to ${pathname}`,
+      level: 'info',
+    });
+  }, [pathname]);
 
   if (!fontsLoaded) return null;
   return (

--- a/src/entity/auth/model/useSignout.ts
+++ b/src/entity/auth/model/useSignout.ts
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { signout } from '../api/signout';
 import { removeData } from '~/shared/lib/removeData';
 import { clearCurrentUserId } from '~/shared/lib/getCurrentUserId';
+import * as Sentry from '@sentry/react-native';
 
 export const useSignout = () => {
   const router = useRouter();
@@ -12,12 +13,14 @@ export const useSignout = () => {
   const signoutMutation = useMutation({
     mutationFn: signout,
     onSuccess: () => {
+      Sentry.setUser(null);
       removeData('memberId');
       clearCurrentUserId();
       queryClient.clear();
       router.replace('/onboarding');
     },
     onError: (error) => {
+      Sentry.setUser(null);
       removeData('memberId');
       clearCurrentUserId();
       queryClient.clear();

--- a/src/entity/chat/hooks/useResilientMessageSender.ts
+++ b/src/entity/chat/hooks/useResilientMessageSender.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useChatQueueStore, MESSAGE_STATUS } from '~/shared/store/useChatQueueStore';
 import type { RoomId, MessageType } from '~/shared/types/chatType';
 import Toast from 'react-native-toast-message';
+import { logger } from '~/shared/lib/logger';
 
 const SEND_TIMEOUT_MS = 10000;
 
@@ -70,7 +71,7 @@ export const useResilientMessageSender = ({
           }
         }, SEND_TIMEOUT_MS);
       } catch (error) {
-        console.error(error);
+        logger.error('Message send failed', error);
         setStatus(tempId, MESSAGE_STATUS.FAILED);
         showSendFailedToast(() => retry(tempId));
       }

--- a/src/entity/chat/lib/socketService.ts
+++ b/src/entity/chat/lib/socketService.ts
@@ -1,5 +1,6 @@
 import type { ISocketManager, BaseSocketMessage, RoomId } from '@/shared/types/chatType';
 import type { ChatMessageResponse } from '../model/chatTypes';
+import { logger } from '@/shared/lib/logger';
 
 export interface ChatSocketEvents {
   connect: () => void;
@@ -42,7 +43,7 @@ export const createChatSocketService = (socketManager: ISocketManager): IChatSoc
         try {
           handler(...args);
         } catch (error) {
-          console.error(`Error in ${event} handler:`, error);
+          logger.error(`Error in ${event} handler`, error);
         }
       });
     }

--- a/src/entity/chat/model/useChatRooms.ts
+++ b/src/entity/chat/model/useChatRooms.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { getChatRooms } from '../api/getChatRooms';
 import { markChatAsRead } from '../api/markChatAsRead';
 import type { ChatRoomListItem, ChatApiError, ChatMessageResponse } from './chatTypes';
+import { logger } from '~/shared/lib/logger';
 
 export const chatRoomKeys = {
   all: ['chatRooms'] as const,
@@ -81,7 +82,7 @@ export const useChatRooms = (options: UseChatRoomsOptions = {}) => {
           unreadMessageCount: 0,
         }));
       } catch (error) {
-        console.error(error);
+        logger.error('markRoomAsRead failed', error);
         updateChatRoom(roomId, (room) => ({
           ...room,
           unreadMessageCount: 0,

--- a/src/entity/chat/model/useMessageSync.ts
+++ b/src/entity/chat/model/useMessageSync.ts
@@ -6,6 +6,7 @@ import type { ChatMessageResponse, ChatRoomListItem } from './chatTypes';
 import type { RoomId } from '@/shared/types/chatType';
 import { getCurrentUserId } from '~/shared/lib/getCurrentUserId';
 import { chatMessageKeys } from './chatQueryKeys';
+import { logger } from '~/shared/lib/logger';
 
 interface UseMessageSyncProps {
   currentRoomId?: RoomId;
@@ -27,7 +28,7 @@ export const useMessageSync = ({
         userIdRef.current = id;
       })
       .catch((error) => {
-        console.error(error);
+        logger.error('Failed to get current user ID', error);
       });
   }, []);
 
@@ -111,7 +112,7 @@ export const useMessageSync = ({
           });
         }
       } catch (error) {
-        console.error(error);
+        logger.error('handleReceiveMessage error', error);
       }
     },
     [queryClient, currentRoomId, chatRoomQueryKey, chatMessageQueryKey]
@@ -177,7 +178,7 @@ export const useMessageSync = ({
       try {
         await markChatAsRead(roomId, lastMessage.messageId);
       } catch (error) {
-        console.error(error);
+        logger.error('markRoomAsRead failed', error);
       } finally {
         resetUnreadCount();
       }

--- a/src/entity/chat/model/useSocketConnection.ts
+++ b/src/entity/chat/model/useSocketConnection.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef, useState } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import type { IChatSocketService } from '../lib/socketService';
+import { logger } from '@/shared/lib/logger';
 
 interface UseSocketConnectionProps {
   socketService: IChatSocketService;
@@ -35,7 +36,7 @@ export const useSocketConnection = ({
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
       if (appStateRef.current.match(/inactive|background/) && nextAppState === 'active') {
         if (autoConnect && !socketService.isConnected) {
-          socketService.connect().catch(console.error);
+          socketService.connect().catch((e) => logger.error('Socket connect failed', e));
         }
       }
       appStateRef.current = nextAppState;
@@ -48,14 +49,14 @@ export const useSocketConnection = ({
   useFocusEffect(
     useCallback(() => {
       if (autoConnect && !socketService.isConnected) {
-        socketService.connect().catch(console.error);
+        socketService.connect().catch((e) => logger.error('Socket connect failed', e));
       }
     }, [autoConnect, socketService])
   );
 
   useEffect(() => {
     if (autoConnect && !socketService.isConnected) {
-      socketService.connect().catch(console.error);
+      socketService.connect().catch((e) => logger.error('Socket connect failed', e));
     }
   }, [autoConnect, socketService]);
 

--- a/src/entity/chat/ui/TradeEmbed/index.tsx
+++ b/src/entity/chat/ui/TradeEmbed/index.tsx
@@ -2,6 +2,7 @@ import React, { memo, useCallback, useState } from 'react';
 import { View, Text, Image, ActivityIndicator } from 'react-native';
 import { Card, Button } from '~/shared/ui';
 import type { TradeProduct } from '~/entity/chat/model/chatTypes';
+import { logger } from '~/shared/lib/logger';
 
 export interface TradeEmbedProps {
   readonly product: TradeProduct;
@@ -38,7 +39,7 @@ const TradeEmbedComponent: React.FC<TradeEmbedProps> = ({
       setLocalLoading(true);
       await onTradeAccept();
     } catch (error) {
-      console.error(error);
+      logger.error('TradeEmbed action failed', error);
     } finally {
       setLocalLoading(false);
     }
@@ -52,7 +53,7 @@ const TradeEmbedComponent: React.FC<TradeEmbedProps> = ({
       await onReservation();
       setIsReserved(true);
     } catch (error) {
-      console.error(error);
+      logger.error('TradeEmbed action failed', error);
     } finally {
       setLocalLoading(false);
     }
@@ -66,7 +67,7 @@ const TradeEmbedComponent: React.FC<TradeEmbedProps> = ({
       await onCancelReservation();
       setIsReserved(false);
     } catch (error) {
-      console.error(error);
+      logger.error('TradeEmbed action failed', error);
     } finally {
       setLocalLoading(false);
     }

--- a/src/entity/main/model/useGetMyInformation.ts
+++ b/src/entity/main/model/useGetMyInformation.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getMyInformation } from '../../../view/main/api/getMyInformation';
 import { ProfileType } from '~/shared/types/profileType';
 import { setData } from '~/shared/lib/setData';
+import * as Sentry from '@sentry/react-native';
 
 export const useGetMyInformation = () => {
   return useQuery<ProfileType>({
@@ -10,6 +11,7 @@ export const useGetMyInformation = () => {
       const data = await getMyInformation();
       if (data && data.memberId) {
         await setData('memberId', data.memberId.toString());
+        Sentry.setUser({ id: data.memberId.toString() });
       }
       return data;
     },

--- a/src/entity/post/hooks/useTradeRequest.ts
+++ b/src/entity/post/hooks/useTradeRequest.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'expo-router';
 import Toast from 'react-native-toast-message';
 import { requestTrade } from '../api/requestTrade';
 import { useChatEntry } from '~/shared/lib/useChatEntry';
+import { logger } from '~/shared/lib/logger';
 
 interface UseTradeRequestOptions {
   readonly productId: number;
@@ -46,7 +47,7 @@ export const useTradeRequest = ({
           await navigateToChat(productId);
         }
       } catch (navigationError) {
-        console.error(navigationError);
+        logger.error('Chat navigation failed', navigationError);
         Toast.show({
           type: 'info',
           text1: '채팅방 이동 중 오류가 발생했습니다',

--- a/src/entity/write/itemForm/api/createItem.ts
+++ b/src/entity/write/itemForm/api/createItem.ts
@@ -1,12 +1,14 @@
 import { instance } from '@/shared/lib/axios';
 import { ItemFormRequestBody } from '../model/itemFormSchema';
 import { getErrorMessage } from '~/shared/lib/errorHandler';
+import { logger } from '~/shared/lib/logger';
+
 export const createItem = async (requestBody: ItemFormRequestBody) => {
   try {
     const response = await instance.post('/post', requestBody);
     return response.data;
   } catch (error) {
-    console.error(error);
+    logger.error('createItem failed', error);
     throw new Error(getErrorMessage(error));
   }
 };

--- a/src/shared/lib/QueryProvider.tsx
+++ b/src/shared/lib/QueryProvider.tsx
@@ -1,10 +1,31 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, QueryCache, MutationCache } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode, useEffect } from 'react';
 import { Platform } from 'react-native';
 import { setQueryClientInstance } from './axios';
+import * as Sentry from '@sentry/react-native';
 
 const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      Sentry.captureException(error, {
+        extra: {
+          queryKey: JSON.stringify(query.queryKey),
+          context: 'react_query_error',
+        },
+      });
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error, _variables, _context, mutation) => {
+      Sentry.captureException(error, {
+        extra: {
+          mutationKey: JSON.stringify(mutation.options.mutationKey),
+          context: 'react_mutation_error',
+        },
+      });
+    },
+  }),
   defaultOptions: {
     queries: {
       retry: 1,

--- a/src/shared/lib/__tests__/axios.test.ts
+++ b/src/shared/lib/__tests__/axios.test.ts
@@ -224,7 +224,7 @@ describe('response interceptor', () => {
 
     await expect(instance.get('/nav-fail')).rejects.toThrow();
 
-    expect(warnSpy).toHaveBeenCalledWith('Router navigation failed:', expect.any(Error));
+    expect(warnSpy).toHaveBeenCalledWith('Router navigation failed', expect.any(Error));
   });
 
   it('동시에 401이 발생해도 토큰 갱신은 한 번만 수행한다', async () => {

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -5,6 +5,7 @@ import { setData } from './setData';
 import { getAccessToken, getRefreshToken, clearAuthTokens } from './auth';
 import { QueryClient } from '@tanstack/react-query';
 import * as Sentry from '@sentry/react-native';
+import { logger } from './logger';
 
 export const baseURL = Constants.expoConfig?.extra?.apiUrl;
 
@@ -26,6 +27,7 @@ export const instance = axios.create({
 
 instance.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
+    (config as any).__sentryStartTime = Date.now();
     const accessToken = await getAccessToken();
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
@@ -43,76 +45,106 @@ instance.interceptors.request.use(
   }
 );
 
-instance.interceptors.response.use(undefined, async (error: AxiosError) => {
-  const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+instance.interceptors.response.use(
+  (response) => {
+    const startTime = (response.config as any).__sentryStartTime;
+    const duration = startTime ? Date.now() - startTime : undefined;
+    Sentry.addBreadcrumb({
+      category: 'http',
+      message: `${response.config.method?.toUpperCase()} ${response.config.url}`,
+      level: 'info',
+      data: {
+        status: response.status,
+        duration_ms: duration,
+      },
+    });
+    return response;
+  },
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+    const startTime = (originalRequest as any).__sentryStartTime;
+    const duration = startTime ? Date.now() - startTime : undefined;
 
-  const isAuthRequest =
-    originalRequest.url?.includes('/auth/signin') || originalRequest.url?.includes('/auth/reissue');
+    Sentry.addBreadcrumb({
+      category: 'http',
+      message: `${originalRequest?.method?.toUpperCase()} ${originalRequest?.url}`,
+      level: 'error',
+      data: {
+        status: error.response?.status,
+        duration_ms: duration,
+      },
+    });
 
-  if (error.response?.status === 401 && !originalRequest._retry && !isAuthRequest) {
-    originalRequest._retry = true;
+    const isAuthRequest =
+      originalRequest.url?.includes('/auth/signin') ||
+      originalRequest.url?.includes('/auth/reissue');
 
-    if (refreshPromise) {
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthRequest) {
+      originalRequest._retry = true;
+
+      if (refreshPromise) {
+        try {
+          const token = await refreshPromise;
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          return instance(originalRequest);
+        } catch (refreshError) {
+          return Promise.reject(refreshError);
+        }
+      }
+
+      refreshPromise = (async () => {
+        Sentry.addBreadcrumb({
+          category: 'auth',
+          message: `401 on ${originalRequest.url}, attempting token refresh`,
+          level: 'warning',
+        });
+
+        const refreshToken = await getRefreshToken();
+        if (!refreshToken) {
+          throw new Error('No refresh token');
+        }
+
+        const response = await instance.post<{ accessToken: string }>('/auth/reissue', {
+          refreshToken,
+        });
+
+        const newAccessToken = response.data.accessToken;
+        await setData('accessToken', newAccessToken);
+        return newAccessToken;
+      })();
+
       try {
-        const token = await refreshPromise;
-        originalRequest.headers.Authorization = `Bearer ${token}`;
+        const newAccessToken = await refreshPromise;
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return instance(originalRequest);
       } catch (refreshError) {
+        Sentry.captureException(refreshError, {
+          extra: {
+            context: 'token_refresh_failed',
+            url: originalRequest.url,
+            errorMessage:
+              refreshError instanceof Error ? refreshError.message : String(refreshError),
+          },
+        });
+
+        await clearAuthTokens();
+
+        if (queryClientInstance) {
+          queryClientInstance.clear();
+        }
+
+        try {
+          router.replace('/signin');
+        } catch (routerError) {
+          logger.warn('Router navigation failed', routerError);
+        }
+
         return Promise.reject(refreshError);
+      } finally {
+        refreshPromise = null;
       }
     }
 
-    refreshPromise = (async () => {
-      Sentry.addBreadcrumb({
-        category: 'auth',
-        message: `401 on ${originalRequest.url}, attempting token refresh`,
-        level: 'warning',
-      });
-
-      const refreshToken = await getRefreshToken();
-      if (!refreshToken) {
-        throw new Error('No refresh token');
-      }
-
-      const response = await instance.post<{ accessToken: string }>('/auth/reissue', {
-        refreshToken,
-      });
-
-      const newAccessToken = response.data.accessToken;
-      await setData('accessToken', newAccessToken);
-      return newAccessToken;
-    })();
-
-    try {
-      const newAccessToken = await refreshPromise;
-      originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-      return instance(originalRequest);
-    } catch (refreshError) {
-      Sentry.captureException(refreshError, {
-        extra: {
-          context: 'token_refresh_failed',
-          url: originalRequest.url,
-          errorMessage: refreshError instanceof Error ? refreshError.message : String(refreshError),
-        },
-      });
-
-      await clearAuthTokens();
-
-      if (queryClientInstance) {
-        queryClientInstance.clear();
-      }
-
-      try {
-        router.replace('/signin');
-      } catch (routerError) {
-        console.warn('Router navigation failed:', routerError);
-      }
-
-      return Promise.reject(refreshError);
-    } finally {
-      refreshPromise = null;
-    }
+    return Promise.reject(error);
   }
-
-  return Promise.reject(error);
-});
+);

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -61,8 +61,10 @@ instance.interceptors.response.use(
     return response;
   },
   async (error: AxiosError) => {
-    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
-    const startTime = (originalRequest as any).__sentryStartTime;
+    const originalRequest = error.config as
+      | (InternalAxiosRequestConfig & { _retry?: boolean })
+      | undefined;
+    const startTime = (originalRequest as any)?.__sentryStartTime;
     const duration = startTime ? Date.now() - startTime : undefined;
 
     Sentry.addBreadcrumb({
@@ -76,10 +78,15 @@ instance.interceptors.response.use(
     });
 
     const isAuthRequest =
-      originalRequest.url?.includes('/auth/signin') ||
-      originalRequest.url?.includes('/auth/reissue');
+      originalRequest?.url?.includes('/auth/signin') ||
+      originalRequest?.url?.includes('/auth/reissue');
 
-    if (error.response?.status === 401 && !originalRequest._retry && !isAuthRequest) {
+    if (
+      originalRequest &&
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !isAuthRequest
+    ) {
       originalRequest._retry = true;
 
       if (refreshPromise) {

--- a/src/shared/lib/sentry.ts
+++ b/src/shared/lib/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: 0.2,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   integrations: [Sentry.mobileReplayIntegration()],

--- a/src/shared/lib/socket.ts
+++ b/src/shared/lib/socket.ts
@@ -3,6 +3,7 @@ import { getData } from './getData';
 import { baseURL } from './axios';
 import Toast from 'react-native-toast-message';
 import type { ISocketManager, SocketConnectionConfig } from '@/shared/types/chatType';
+import { logger } from './logger';
 
 const SOCKET_URL = (baseURL ?? '').replace(/\/$/, '') + '/chat';
 
@@ -85,7 +86,7 @@ class SocketManager implements ISocketManager {
       });
     } catch (error) {
       this.isConnecting = false;
-      console.error('Socket connection error:', error);
+      logger.error('Socket connection error', error);
       throw error;
     }
   }
@@ -111,7 +112,7 @@ class SocketManager implements ISocketManager {
   }
 
   private handleConnectionError(error: Error): void {
-    console.error('Socket connection error:', error);
+    logger.error('Socket connection error', error);
     this.emit('connect_error', error);
 
     let errorMessage = error.message;
@@ -149,7 +150,7 @@ class SocketManager implements ISocketManager {
         try {
           handler(...args);
         } catch (error) {
-          console.error(`Error in ${event} handler:`, error);
+          logger.error(`Error in ${event} handler`, error);
         }
       });
     }

--- a/src/shared/lib/useNetworkStatus.ts
+++ b/src/shared/lib/useNetworkStatus.ts
@@ -1,12 +1,23 @@
 import { useEffect, useState } from 'react';
 import NetInfo from '@react-native-community/netinfo';
+import * as Sentry from '@sentry/react-native';
 
 export function useNetworkStatus() {
   const [isConnected, setIsConnected] = useState(true);
 
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener((state) => {
-      setIsConnected(state.isConnected ?? false);
+      const connected = state.isConnected ?? false;
+      setIsConnected(connected);
+      Sentry.addBreadcrumb({
+        category: 'network',
+        message: connected ? 'Network connected' : 'Network disconnected',
+        level: connected ? 'info' : 'warning',
+        data: {
+          type: state.type,
+          isInternetReachable: state.isInternetReachable,
+        },
+      });
     });
 
     return unsubscribe;

--- a/src/shared/model/getDeviceInfo.ts
+++ b/src/shared/model/getDeviceInfo.ts
@@ -5,6 +5,7 @@ import { setData } from '../lib/setData';
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
 import * as Sentry from '@sentry/react-native';
+import { logger } from '../lib/logger';
 
 const registerForPushNotificationsAsync = async (): Promise<string | null> => {
   if (!Device.isDevice) {
@@ -35,7 +36,7 @@ const registerForPushNotificationsAsync = async (): Promise<string | null> => {
   const projectId = Constants.expoConfig?.extra?.eas?.projectId ?? Constants.easConfig?.projectId;
 
   if (!projectId) {
-    console.warn(
+    logger.warn(
       'Project ID를 찾을 수 없어 default 설정을 시도합니다. app.json 설정을 확인해 주세요.'
     );
   }
@@ -92,7 +93,7 @@ const generateDeviceId = async (): Promise<string> => {
 
     return deviceId;
   } catch (error) {
-    console.error(error);
+    logger.error('generateDeviceId failed', error);
     const randomId = Math.random().toString(36).substring(2, 18);
     await setData('deviceId', randomId);
     return randomId;

--- a/src/view/chat/ui/ChatRoomPage/index.tsx
+++ b/src/view/chat/ui/ChatRoomPage/index.tsx
@@ -2,6 +2,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Text, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
 import { useState, useCallback, useEffect, useMemo } from 'react';
+import { logger } from '~/shared/lib/logger';
 import { useChatMessages } from '~/widget/chat/model/useChatMessages';
 import { useChatAction } from '~/widget/chat/model/useChatActions';
 import { useTradeHandlers } from '~/widget/chat/model/useTradeHandlers';
@@ -76,7 +77,7 @@ export default function ChatRoomPage() {
 
   useEffect(() => {
     if (roomId) {
-      markRoomAsRead(roomId).catch(console.error);
+      markRoomAsRead(roomId).catch((e) => logger.error('markRoomAsRead failed', e));
     }
   }, [roomId, markRoomAsRead]);
 
@@ -101,7 +102,7 @@ export default function ChatRoomPage() {
       await executeTradeRequest();
       setIsTradeRequestModalVisible(false);
     } catch (error) {
-      console.error(error);
+      logger.error('handleTradeRequest failed', error);
     }
   }, [executeTradeRequest]);
 
@@ -119,7 +120,7 @@ export default function ChatRoomPage() {
         setReviewLight(60);
         setReviewContents('');
       } catch (error) {
-        console.error('리뷰 작성 실패:', error);
+        logger.error('리뷰 작성 실패', error);
       }
     },
     [roomData?.product?.id]

--- a/src/view/reviews/api/getReviews.ts
+++ b/src/view/reviews/api/getReviews.ts
@@ -1,11 +1,12 @@
 import Toast from 'react-native-toast-message';
 import { instance } from '~/shared/lib/axios';
+import { logger } from '~/shared/lib/logger';
 
 export const getReceiveReview = async (id: string) => {
   try {
     return await instance.get(`/review/${id}`);
   } catch (error) {
-    console.error(error);
+    logger.error('getReceiveReview failed', error);
     Toast.show({
       type: 'error',
       text1: '후기 조회 실패',
@@ -19,7 +20,7 @@ export const getTossReview = async () => {
   try {
     return await instance.get('/review');
   } catch (error) {
-    console.error(error);
+    logger.error('getTossReview failed', error);
     Toast.show({
       type: 'error',
       text1: '후기 조회 실패',

--- a/src/view/reviews/ui/PostsPage/index.tsx
+++ b/src/view/reviews/ui/PostsPage/index.tsx
@@ -6,6 +6,7 @@ import { Header } from '~/shared/ui';
 import { getReceiveReview, getTossReview } from '../../api/getReviews';
 import { ReviewPostType } from '../../model/reviewPostType';
 import { ReviewPost } from '~/entity/reviews/ui';
+import { logger } from '~/shared/lib/logger';
 
 export default function ReviewsPageView() {
   const rawParams = useLocalSearchParams();
@@ -23,7 +24,7 @@ export default function ReviewsPageView() {
           setPosts(res.data);
         }
       } catch (error) {
-        console.error(error);
+        logger.error('getReviews failed', error);
         setPosts([]);
       }
     };

--- a/src/view/write/itemForm/ui/ItemFormPage/index.tsx
+++ b/src/view/write/itemForm/ui/ItemFormPage/index.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import { logger } from '@/shared/lib/logger';
 import { Header } from '@/shared/ui';
 import {
   ItemFormProgressBar,
@@ -136,7 +137,7 @@ const ItemFormPage = () => {
         pathname: '/main',
       });
     } catch (error) {
-      console.error(error);
+      logger.error('ItemForm submit failed', error);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/widget/chat/model/useChatInput.ts
+++ b/src/widget/chat/model/useChatInput.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { useUploadImage } from '@/shared/model/useUploadImage';
+import { logger } from '@/shared/lib/logger';
 
 export interface ImagePreview {
   imageId: number;
@@ -56,7 +57,7 @@ export const useChatInput = ({ onSendMessage, disabled = false }: UseChatInputPr
       }
       return null;
     } catch (error) {
-      console.error(error);
+      logger.error('useChatInput error', error);
       Alert.alert('오류', '이미지 선택 중 오류가 발생했습니다.');
       return null;
     }
@@ -67,7 +68,7 @@ export const useChatInput = ({ onSendMessage, disabled = false }: UseChatInputPr
       try {
         return await uploadImageMutation.mutateAsync(imageUri);
       } catch (error) {
-        console.error(error);
+        logger.error('useChatInput error', error);
         Alert.alert('오류', '이미지 업로드 중 오류가 발생했습니다.');
         throw error;
       }


### PR DESCRIPTION
- tracesSampleRate 추가로 퍼포먼스 모니터링 활성화
- 로그인/로그아웃 시 Sentry.setUser() 설정으로 유저 컨텍스트 추적
- QueryCache/MutationCache global onError로 React Query 에러 Sentry 전송
- Axios 인터셉터에 API 응답 시간(duration_ms) breadcrumb 추가
- 네트워크 상태 변화 및 앱 생명주기 breadcrumb 추가
- 화면 전환(pathname) breadcrumb 추가
- 전체 console.error/warn → logger로 통일 (소켓, 채팅, 리뷰 등 22개 파일)