### PR TITLE
chore: update package-lock.json for yaml@2.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20010,6 +20010,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",


### PR DESCRIPTION
## 변경사항
- package.json과 package-lock.json 불일치로 인한 CI npm ci 실패 수정
yaml@2.8.3 누락 → npm install 실행으로 lock 파일 동기화