### PR TITLE
fix: switch appVersionSource to local to fix iOS App Store rejection

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.13.3",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {

--- a/eas.json
+++ b/eas.json
@@ -42,7 +42,6 @@
     },
     "production": {
       "environment": "production",
-      "autoIncrement": true,
       "env": {
         "NODE_ENV": "production",
         "SENTRY_DISABLE_AUTO_UPLOAD": "true"


### PR DESCRIPTION
CD workflow bumps app.json version automatically; remote versioning was stuck at 1.0.5 which App Store Connect rejected as a closed train.