### PR TITLE
fix: resolve iOS App Store version rejection

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -1,6 +1,7 @@
 name: Android CD
 
 on:
+  workflow_dispatch:
   push:
     branches: ['main']
 
@@ -11,13 +12,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+
+      - name: Bump versionCode
+        run: |
+          CURRENT=$(node -p "require('./app.json').expo.android?.versionCode ?? 0")
+          NEW=$((CURRENT + 1))
+          node -e "
+            const fs = require('fs');
+            const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+            app.expo.android.versionCode = $NEW;
+            fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
+          "
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add app.json
+          git commit -m "chore: bump versionCode to $NEW [skip ci]"
+          git push
 
       - name: Install dependencies
         run: |

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "jsEngine": "hermes",
     "name": "시민화폐 광산",
     "slug": "my-expo-app",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "scheme": "gwangsan",
     "web": {
       "favicon": "./src/app/favicon.ico"

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "jsEngine": "hermes",
     "name": "시민화폐 광산",
     "slug": "my-expo-app",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "scheme": "gwangsan",
     "web": {
       "favicon": "./src/app/favicon.ico"

--- a/app.json
+++ b/app.json
@@ -61,7 +61,8 @@
         "backgroundColor": "#ffffff"
       },
       "package": "gwangsan.io.kr",
-      "googleServicesFile": "./google-services.json"
+      "googleServicesFile": "./google-services.json",
+      "versionCode": 10
     },
     "extra": {
       "eas": {

--- a/app.json
+++ b/app.json
@@ -48,6 +48,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "kr.hs.gsm.gwangsan",
+      "buildNumber": "1",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSPhotoLibraryUsageDescription": "거래 게시글 업로드 및 채팅에 사용할 이미지 업로드를 위해 저장공간에 접근합니다.",

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "jsEngine": "hermes",
     "name": "시민화폐 광산",
     "slug": "my-expo-app",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "scheme": "gwangsan",
     "web": {
       "favicon": "./src/app/favicon.ico"

--- a/app.json
+++ b/app.json
@@ -63,7 +63,7 @@
       },
       "package": "gwangsan.io.kr",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 10
+      "versionCode": 50
     },
     "extra": {
       "eas": {

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "jsEngine": "hermes",
     "name": "시민화폐 광산",
     "slug": "my-expo-app",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "scheme": "gwangsan",
     "web": {
       "favicon": "./src/app/favicon.ico"

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.13.3",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {

--- a/eas.json
+++ b/eas.json
@@ -42,7 +42,6 @@
     },
     "production": {
       "environment": "production",
-      "autoIncrement": true,
       "env": {
         "NODE_ENV": "production",
         "SENTRY_DISABLE_AUTO_UPLOAD": "true"

--- a/src/entity/post/api/__tests__/getItem.test.ts
+++ b/src/entity/post/api/__tests__/getItem.test.ts
@@ -1,0 +1,94 @@
+import { getItem } from '../getItem';
+import { instance } from '~/shared/lib/axios';
+
+jest.mock('~/shared/lib/axios', () => ({
+  instance: { get: jest.fn() },
+}));
+
+const mockGet = instance.get as jest.Mock;
+
+const makePostDetail = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: '상세 게시글',
+  content: '상세 내용',
+  gwangsan: 1,
+  type: 'OBJECT',
+  mode: 'GIVER',
+  images: [{ imageId: 1, imageUrl: 'https://example.com/img.jpg' }],
+  isCompletable: true,
+  isCompleted: false,
+  member: {
+    memberId: 42,
+    nickname: '홍길동',
+    placeName: '광산구',
+    light: 80,
+  },
+  ...overrides,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getItem', () => {
+  describe('성공 케이스', () => {
+    it('GET /post/:id 응답 data를 반환한다', async () => {
+      const detail = makePostDetail();
+      mockGet.mockResolvedValue({ data: detail });
+
+      const result = await getItem('1');
+
+      expect(mockGet).toHaveBeenCalledWith('/post/1');
+      expect(result).toEqual(detail);
+    });
+
+    it('다른 postId로 올바른 경로를 요청한다', async () => {
+      mockGet.mockResolvedValue({ data: makePostDetail({ id: 99 }) });
+
+      await getItem('99');
+
+      expect(mockGet).toHaveBeenCalledWith('/post/99');
+    });
+
+    it('images 배열이 비어있는 게시글도 정상 반환한다', async () => {
+      const detail = makePostDetail({ images: [] });
+      mockGet.mockResolvedValue({ data: detail });
+
+      const result = await getItem('1');
+
+      expect(result.images).toEqual([]);
+    });
+
+    it('member 정보를 포함한 응답을 반환한다', async () => {
+      const detail = makePostDetail();
+      mockGet.mockResolvedValue({ data: detail });
+
+      const result = await getItem('1');
+
+      expect(result.member).toEqual({
+        memberId: 42,
+        nickname: '홍길동',
+        placeName: '광산구',
+        light: 80,
+      });
+    });
+  });
+
+  describe('에러 케이스', () => {
+    it('API 실패 시 에러를 throw한다', async () => {
+      mockGet.mockRejectedValue(new Error('Not found'));
+
+      await expect(getItem('999')).rejects.toThrow();
+    });
+
+    it('에러 메시지가 getErrorMessage를 통해 래핑된다', async () => {
+      mockGet.mockRejectedValue(new Error('Server error'));
+
+      await expect(getItem('1')).rejects.toThrow(Error);
+    });
+
+    it('네트워크 에러 시 에러를 throw한다', async () => {
+      mockGet.mockRejectedValue(new Error('Network Error'));
+
+      await expect(getItem('1')).rejects.toThrow('Network Error');
+    });
+  });
+});

--- a/src/entity/post/model/__tests__/useGetItem.test.ts
+++ b/src/entity/post/model/__tests__/useGetItem.test.ts
@@ -1,0 +1,106 @@
+import { waitFor } from '@testing-library/react-native';
+import { renderHookWithProviders } from '~/test-utils';
+import { useGetItem } from '../useGetItem';
+import { getItem } from '../../api/getItem';
+
+jest.mock('../../api/getItem', () => ({
+  getItem: jest.fn(),
+}));
+
+const mockGetItem = getItem as jest.Mock;
+
+const makePostDetail = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: '상세 게시글',
+  content: '상세 내용',
+  gwangsan: 1,
+  type: 'OBJECT',
+  mode: 'GIVER',
+  images: [{ imageId: 1, imageUrl: 'https://example.com/img.jpg' }],
+  isCompletable: true,
+  isCompleted: false,
+  member: {
+    memberId: 42,
+    nickname: '홍길동',
+    placeName: '광산구',
+    light: 80,
+  },
+  ...overrides,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('useGetItem', () => {
+  describe('데이터 로딩', () => {
+    it('postId가 있으면 getItem을 호출하고 데이터를 반환한다', async () => {
+      const detail = makePostDetail();
+      mockGetItem.mockResolvedValue(detail);
+
+      const { result } = renderHookWithProviders(() => useGetItem('1'));
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockGetItem).toHaveBeenCalledWith('1');
+      expect(result.current.data).toEqual(detail);
+    });
+
+    it('postId가 undefined이면 쿼리가 비활성화된다', () => {
+      const { result } = renderHookWithProviders(() => useGetItem(undefined));
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(mockGetItem).not.toHaveBeenCalled();
+    });
+
+    it('postId가 빈 문자열이면 쿼리가 비활성화된다', () => {
+      const { result } = renderHookWithProviders(() => useGetItem(''));
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(mockGetItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('쿼리 키', () => {
+    it('queryKey가 [post, postId] 형태이다', async () => {
+      mockGetItem.mockResolvedValue(makePostDetail());
+
+      const { queryClient } = renderHookWithProviders(() => useGetItem('5'));
+
+      await waitFor(() =>
+        expect(queryClient.getQueryState(['post', '5'])).toBeDefined()
+      );
+    });
+
+    it('다른 postId에 대해 별도 캐시 항목을 생성한다', async () => {
+      mockGetItem.mockResolvedValue(makePostDetail());
+
+      const { queryClient } = renderHookWithProviders(() => useGetItem('10'));
+
+      await waitFor(() =>
+        expect(queryClient.getQueryState(['post', '10'])).toBeDefined()
+      );
+      expect(queryClient.getQueryState(['post', '5'])).toBeUndefined();
+    });
+  });
+
+  describe('에러 상태', () => {
+    it('API 실패 시 error 상태가 된다', async () => {
+      mockGetItem.mockRejectedValue(new Error('Not found'));
+
+      const { result } = renderHookWithProviders(() => useGetItem('999'));
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+
+  describe('로딩 상태', () => {
+    it('초기에 isLoading이 true이다', () => {
+      mockGetItem.mockReturnValue(new Promise(() => {})); // never resolves
+
+      const { result } = renderHookWithProviders(() => useGetItem('1'));
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+});

--- a/src/mocks/handlers/post.ts
+++ b/src/mocks/handlers/post.ts
@@ -1,0 +1,44 @@
+import { http, HttpResponse } from 'msw';
+
+const BASE = 'http://test-api.com';
+
+export const makePostListItem = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: '테스트 게시글',
+  content: '테스트 내용',
+  gwangsan: 1,
+  type: 'OBJECT',
+  mode: 'GIVER',
+  images: [{ imageId: 1, imageUrl: 'https://example.com/img.jpg' }],
+  isCompletable: true,
+  isCompleted: false,
+  ...overrides,
+});
+
+export const makePostDetail = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  title: '상세 게시글',
+  content: '상세 내용',
+  gwangsan: 1,
+  type: 'OBJECT',
+  mode: 'GIVER',
+  images: [{ imageId: 1, imageUrl: 'https://example.com/img.jpg' }],
+  isCompletable: true,
+  isCompleted: false,
+  member: {
+    memberId: 42,
+    nickname: '홍길동',
+    placeName: '광산구',
+    light: 80,
+  },
+  ...overrides,
+});
+
+export const postHandlers = [
+  http.get(`${BASE}/post`, () => HttpResponse.json([makePostListItem()])),
+
+  http.get(`${BASE}/post/:postId`, ({ params }) => {
+    const { postId } = params;
+    return HttpResponse.json(makePostDetail({ id: Number(postId) }));
+  }),
+];


### PR DESCRIPTION
## Summary
- `appVersionSource`를 `remote` → `local`로 변경하여 EAS가 `app.json` 버전을 읽도록 수정
- `autoIncrement: true` 제거 — local 소스에서 클라우드 빌드 중 `app.json`을 수정하지만 git에 반영되지 않아 다음 빌드 시 버전 충돌 발생

## Root Cause
`appVersionSource: remote`로 설정되어 있어 EAS의 원격 버전(1.0.5)을 사용했고, App Store Connect에서 해당 버전 트레인이 닫혀 빌드가 거부됨.
CD 워크플로우(`ios_cd.yml`)가 이미 `app.json`의 버전을 자동 bump하므로 `local` 소스로 전환이 올바른 해결책.

## Test plan
- [ ] EAS build production 실행 시 `app.json`의 버전(1.0.9 이상)을 읽는지 확인
- [ ] `main` 푸시 시 CD가 버전을 자동 bump하고 빌드/제출이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)