### PR TITLE
fix: iOS 카메라 및 Face ID 권한 설명 추가

### DIFF
--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -55,6 +55,10 @@
 	</dict>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>거래 게시글 업로드 및 채팅에 사용할 이미지 업로드를 위해 저장공간에 접근합니다.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>거래 게시글 업로드 및 채팅에 사용할 사진을 촬영하기 위해 카메라를 사용합니다.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>생체 인증을 통해 안전하게 로그인하기 위해 Face ID를 사용합니다.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>


### PR DESCRIPTION
## Summary

- `NSCameraUsageDescription` 추가 — 기존에 카메라 촬영 기능(`launchCameraAsync`)이 구현되어 있었으나 Info.plist에 키가 없어 iOS가 카메라 접근 시 앱을 강제 종료시키는 버그 수정
- `NSFaceIDUsageDescription` 추가 — `react-native-keychain`으로 Face ID 생체 인증 로그인이 구현되어 있으나 권한 설명이 누락

## Test plan

- [ ] 게시글 작성 화면에서 이미지 첨부 → "카메라로 촬영" 선택 시 앱이 종료되지 않고 카메라 권한 요청 알림이 뜨는지 확인
- [ ] 채팅 화면에서 이미지 첨부 → "카메라로 촬영" 선택 시 동일하게 정상 동작하는지 확인
- [ ] 로그인 화면 진입 시 Face ID 인증 팝업이 정상 표시되는지 확인
- [ ] 권한 거부 후 재요청 시 Toast/Alert 안내 메시지가 표시되는지 확인