### PR TITLE
fix: Footer 공지 탭 정렬 및 NoticePage SafeArea 수정

### DIFF
--- a/src/shared/ui/Footer/index.tsx
+++ b/src/shared/ui/Footer/index.tsx
@@ -9,7 +9,9 @@ export function Footer() {
 
   return (
     <View className="relative bottom-0 w-full flex-row justify-between border-t border-gray-200 bg-white px-6 py-3">
-      <TouchableOpacity className="flex items-center" onPress={() => router.push('/main')}>
+      <TouchableOpacity
+        className="flex items-center justify-center"
+        onPress={() => router.push('/main')}>
         <Ionicons
           name="home-outline"
           size={24}
@@ -17,7 +19,9 @@ export function Footer() {
         />
         <Text className={pathname === '/main' ? 'text-[#8FC31D]' : 'text-gray-500'}>홈</Text>
       </TouchableOpacity>
-      <TouchableOpacity className="flex items-center" onPress={() => router.push('/chatting')}>
+      <TouchableOpacity
+        className="flex items-center justify-center"
+        onPress={() => router.push('/chatting')}>
         <Ionicons
           name="chatbubble-outline"
           size={24}
@@ -25,7 +29,9 @@ export function Footer() {
         />
         <Text className={pathname === '/chatting' ? 'text-[#8FC31D]' : 'text-gray-500'}>채팅</Text>
       </TouchableOpacity>
-      <TouchableOpacity className="flex items-center" onPress={() => router.push('/write')}>
+      <TouchableOpacity
+        className="flex items-center justify-center"
+        onPress={() => router.push('/write')}>
         <Svg width={33} height={32} viewBox="0 0 33 32" fill="none">
           <Path
             d="M16.5 0C7.67785 0 0.5 7.17785 0.5 16C0.5 24.8222 7.67785 32 16.5 32C25.3222 32 32.5 24.8222 32.5 16C32.5 7.17785 25.3222 0 16.5 0ZM16.5 2.46154C23.9917 2.46154 30.0385 8.50831 30.0385 16C30.0385 23.4917 23.9917 29.5385 16.5 29.5385C9.00831 29.5385 2.96154 23.4917 2.96154 16C2.96154 8.50831 9.00831 2.46154 16.5 2.46154ZM15.2692 8.61539V14.7692H9.11539V17.2308H15.2692V23.3846H17.7308V17.2308H23.8846V14.7692H17.7308V8.61539H15.2692Z"
@@ -33,7 +39,9 @@ export function Footer() {
           />
         </Svg>
       </TouchableOpacity>
-      <TouchableOpacity className="flex items-center" onPress={() => router.push('/notice')}>
+      <TouchableOpacity
+        className="flex items-center justify-center"
+        onPress={() => router.push('/notice')}>
         <Ionicons
           name="megaphone-outline"
           size={24}
@@ -43,7 +51,7 @@ export function Footer() {
       </TouchableOpacity>
       <TouchableOpacity
         testID="Footer-profile-button"
-        className="flex items-center"
+        className="flex items-center justify-center"
         onPress={() => router.push('/profile')}>
         <Ionicons
           name="person-outline"

--- a/src/view/notice/ui/NoticePage/index.tsx
+++ b/src/view/notice/ui/NoticePage/index.tsx
@@ -57,7 +57,7 @@ const NoticePage = () => {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-white" edges={['top']}>
+    <SafeAreaView className="flex-1 bg-white">
       <Header headerTitle="공지" />
       {renderContent()}
       <Footer />


### PR DESCRIPTION
## issue number
#300 

## Summary

- `Footer` 컴포넌트의 각 `TouchableOpacity`에 `justify-center` 추가 — 공지 탭 아이콘이 다른 탭보다 내려가 보이던 수직 정렬 문제 해결
- `NoticePage` `SafeAreaView`의 `edges={['top']}` 제거 — 공지 탭 진입 시 Footer가 내려가던 문제 해결 (하단 홈 인디케이터 safe area 미적용이 원인)

## Test plan

- [x] 하단바의 홈 / 채팅 / 글쓰기 / 공지 / 프로필 탭 아이콘과 텍스트가 동일한 수직 기준선에 정렬되는지 확인
- [x] 공지 탭 클릭 시 Footer 위치가 다른 페이지와 동일한지 확인 (iPhone 홈 인디케이터 기기에서 확인)
- [x] 글쓰기(SVG) 아이콘이 잘리지 않고 정상 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)