### PR TITLE
chore: sync package-lock.json for yaml@2.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14036,9 +14036,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -14809,9 +14809,9 @@
       }
     },
     "node_modules/metro-config/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## Summary

- `yaml@2.8.4` 패치 릴리즈로 인해 `lint-staged`, `metro-config`의 nested yaml 버전이 lock file과 불일치하여 CI `npm ci` 실패 (`Missing: yaml@2.8.4 from lock file`)
- `npm update yaml --package-lock-only`로 두 항목 모두 `2.8.4`로 갱신

## Test plan

- [ ] CI `npm ci` 스텝이 에러 없이 통과되는지 확인
- [ ] E2E (iOS/Android) 워크플로우가 lock file 문제 없이 실행되는지 확인