### PR TITLE
fix: typing 글자 가림 오류 수정

### DIFF
--- a/src/view/chat/ui/ChatRoomPage/index.tsx
+++ b/src/view/chat/ui/ChatRoomPage/index.tsx
@@ -165,7 +165,7 @@ export default function ChatRoomPage() {
       />
 
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         className="flex-1"
         keyboardVerticalOffset={0}>
         <ChatRoomContent


### PR DESCRIPTION
## 💡 PR 요약

#308 
Android에서 키보드가 올라올 때 채팅 입력창이 가려지는 문제를 수정하였습니다


## 📋 작업 내용
ChatRoomPage의 KeyboardAvoidingView에서 Android의 behavior 속성이 undefined로 설정되어 있어 키보드가 올라와도 레이아웃이 조정되지 않는 문제를 수정했습니다.

