### PR TITLE
fix: 채팅 푸시 알림 미수신 문제 해결

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { Stack, usePathname } from 'expo-router';
+import { Stack, usePathname, router } from 'expo-router';
 import { AppState, View } from 'react-native';
 import { useEffect } from 'react';
 import { saveE2ECoverage } from '@/shared/lib/e2eCoverage';
@@ -10,11 +10,36 @@ import '@/shared/lib/sentry';
 import * as SentryRN from '@sentry/react-native';
 import { useNetworkStatus } from '@/shared/lib/useNetworkStatus';
 import { NoNetworkOverlay } from '@/shared/ui/NoNetworkOverlay';
+import * as Notifications from 'expo-notifications';
+import { AlertType } from '@/entity/notification';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
 
 export default function RootLayout() {
   const fontsLoaded = useCustomFonts();
   const isConnected = useNetworkStatus();
   const pathname = usePathname();
+
+  useEffect(() => {
+    const sub = Notifications.addNotificationResponseReceivedListener((response) => {
+      const data = response.notification.request.content.data as {
+        alertType?: AlertType;
+        sourceId?: number;
+      };
+      if (data?.alertType === AlertType.CHTTING_REQUEST && data?.sourceId) {
+        router.push(`/chatting/${data.sourceId}`);
+      }
+    });
+    return () => sub.remove();
+  }, []);
 
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout() {
         alertType?: AlertType;
         sourceId?: number;
       };
-      if (data?.alertType === AlertType.CHTTING_REQUEST && data?.sourceId) {
+      if (data?.alertType === AlertType.CHTTING_REQUEST && data?.sourceId != null) {
         router.push(`/chatting/${data.sourceId}`);
       }
     });

--- a/src/entity/notification/index.ts
+++ b/src/entity/notification/index.ts
@@ -1,3 +1,4 @@
 export { getAlertList } from './api/getAlertList';
 export { useGetAlertList } from './model/useGetAlertList';
-export type { Alert, AlertListResponse, AlertType } from './model/alertTypes';
+export { AlertType } from './model/alertTypes';
+export type { Alert, AlertListResponse } from './model/alertTypes';


### PR DESCRIPTION
## Summary

- `Notifications.setNotificationHandler()`가 등록되지 않아 앱이 포그라운드 상태일 때 푸시 알림이 표시되지 않던 문제 수정
- `addNotificationResponseReceivedListener`를 추가하여 채팅 알림(`CHTTING_REQUEST`) 탭 시 해당 채팅방(`/chatting/:id`)으로 자동 이동
- `AlertType` enum을 `export type`으로만 내보내던 것을 값으로도 사용할 수 있도록 barrel export 수정

## Test plan

- [ ] 앱이 포그라운드 상태에서 상대방이 채팅 메시지를 보낼 때 배너 알림이 표시되는지 확인 (iOS / Android 각각)
- [ ] 앱이 백그라운드 상태에서 채팅 알림 수신 후 탭했을 때 해당 채팅방 화면으로 이동하는지 확인
- [ ] 앱이 완전히 종료된 상태에서 채팅 알림 탭 후 앱 진입 시 해당 채팅방으로 이동하는지 확인
- [ ] 채팅 외 다른 알림 탭 시 채팅방으로 이동하지 않는지 확인