### PR TITLE
fix: 로그아웃 후 재로그인 시 메인화면으로 튕기는 현상 수정

### DIFF
--- a/src/entity/auth/api/signin.ts
+++ b/src/entity/auth/api/signin.ts
@@ -74,6 +74,14 @@ export const getCredentialsForBiometric = async (): Promise<{
   }
 };
 
+export const clearCredentialsForBiometric = async (): Promise<void> => {
+  try {
+    await Keychain.resetGenericPassword();
+  } catch (error) {
+    logger.error('Failed to clear biometric credentials', error);
+  }
+};
+
 export const signinWithDeviceInfo = async (credentials: {
   nickname: string;
   password: string;

--- a/src/entity/auth/model/__tests__/useSignout.test.ts
+++ b/src/entity/auth/model/__tests__/useSignout.test.ts
@@ -12,6 +12,9 @@ jest.mock('expo-router', () => ({
 jest.mock('../../api/signout', () => ({
   signout: jest.fn(),
 }));
+jest.mock('../../api/signin', () => ({
+  clearCredentialsForBiometric: jest.fn(),
+}));
 jest.mock('~/shared/lib/removeData', () => ({
   removeData: jest.fn(),
 }));

--- a/src/entity/auth/model/__tests__/useSignout.test.ts
+++ b/src/entity/auth/model/__tests__/useSignout.test.ts
@@ -1,6 +1,7 @@
 import { act, waitFor } from '@testing-library/react-native';
 import { useRouter } from 'expo-router';
 import { signout } from '../../api/signout';
+import { clearCredentialsForBiometric } from '../../api/signin';
 import { removeData } from '~/shared/lib/removeData';
 import { clearCurrentUserId } from '~/shared/lib/getCurrentUserId';
 import { renderHookWithProviders } from '~/test-utils';
@@ -24,6 +25,7 @@ jest.mock('~/shared/lib/getCurrentUserId', () => ({
 
 const mockUseRouter = useRouter as jest.Mock;
 const mockSignout = signout as jest.Mock;
+const mockClearCredentialsForBiometric = clearCredentialsForBiometric as jest.Mock;
 const mockRemoveData = removeData as jest.Mock;
 const mockClearCurrentUserId = clearCurrentUserId as jest.Mock;
 
@@ -33,6 +35,7 @@ describe('useSignout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseRouter.mockReturnValue({ replace: mockReplace });
+    mockClearCredentialsForBiometric.mockResolvedValue(undefined);
     mockRemoveData.mockResolvedValue(undefined);
   });
 
@@ -54,6 +57,7 @@ describe('useSignout', () => {
     });
 
     await waitFor(() => {
+      expect(mockClearCredentialsForBiometric).toHaveBeenCalled();
       expect(mockRemoveData).toHaveBeenCalledWith('memberId');
       expect(mockClearCurrentUserId).toHaveBeenCalled();
       expect(mockReplace).toHaveBeenCalledWith('/onboarding');
@@ -125,6 +129,7 @@ describe('useSignout', () => {
       });
 
       await waitFor(() => {
+        expect(mockClearCredentialsForBiometric).toHaveBeenCalled();
         expect(mockRemoveData).toHaveBeenCalledWith('memberId');
         expect(mockClearCurrentUserId).toHaveBeenCalled();
         expect(mockReplace).toHaveBeenCalledWith('/onboarding');

--- a/src/entity/auth/model/useSignout.ts
+++ b/src/entity/auth/model/useSignout.ts
@@ -2,6 +2,7 @@ import { useRouter } from 'expo-router';
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { signout } from '../api/signout';
+import { clearCredentialsForBiometric } from '../api/signin';
 import { removeData } from '~/shared/lib/removeData';
 import { clearCurrentUserId } from '~/shared/lib/getCurrentUserId';
 import * as Sentry from '@sentry/react-native';
@@ -11,6 +12,7 @@ export const useSignout = () => {
   const queryClient = useQueryClient();
 
   const cleanup = () => {
+    clearCredentialsForBiometric();
     removeData('memberId');
     clearCurrentUserId();
     Sentry.setUser(null);

--- a/src/entity/auth/model/useSignout.ts
+++ b/src/entity/auth/model/useSignout.ts
@@ -11,9 +11,8 @@ export const useSignout = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const cleanup = () => {
-    clearCredentialsForBiometric();
-    removeData('memberId');
+  const cleanup = async () => {
+    await Promise.allSettled([clearCredentialsForBiometric(), removeData('memberId')]);
     clearCurrentUserId();
     Sentry.setUser(null);
     queryClient.clear();
@@ -23,8 +22,8 @@ export const useSignout = () => {
   const signoutMutation = useMutation({
     mutationFn: signout,
     onSuccess: cleanup,
-    onError: (error) => {
-      cleanup();
+    onError: async (error) => {
+      await cleanup();
       throw error;
     },
   });


### PR DESCRIPTION
## issue tag
#316 

## Summary

- 로그아웃 시 `react-native-keychain`에 저장된 생체인증 자격증명을 삭제하지 않아, 재로그인 화면 진입 시 `NicknameStep`의 `useEffect`가 구 토큰을 자동으로 불러와 `/main`으로 redirect되는 버그 수정
- `clearCredentialsForBiometric()` 함수를 추가하고 로그아웃 `cleanup()` 시 호출하여 Keychain을 함께 초기화