### PR TITLE
fix: 거래 상태 실시간 동기화 및 채팅 메뉴 버튼 노출 개선

### DIFF
--- a/src/entity/chat/lib/socketService.ts
+++ b/src/entity/chat/lib/socketService.ts
@@ -2,6 +2,14 @@ import type { ISocketManager, BaseSocketMessage, RoomId } from '@/shared/types/c
 import type { ChatMessageResponse } from '../model/chatTypes';
 import { logger } from '@/shared/lib/logger';
 
+export interface TransactionStateChangedPayload {
+  roomId: number;
+  targetMemberId?: number;
+  productId: number;
+  isCompleted: boolean;
+  createdAt: string;
+}
+
 export interface ChatSocketEvents {
   connect: () => void;
   disconnect: (reason: string) => void;
@@ -13,6 +21,7 @@ export interface ChatSocketEvents {
     lastMessageType: string;
     lastMessageTime: string;
   }) => void;
+  transactionStateChanged: (data: TransactionStateChangedPayload) => void;
 }
 
 export interface ChatSendMessagePayload extends BaseSocketMessage {
@@ -68,6 +77,10 @@ export const createChatSocketService = (socketManager: ISocketManager): IChatSoc
 
     socketManager.on('updateRoomList', (data: any) => {
       emit('updateRoomList', data);
+    });
+
+    socketManager.on('transactionStateChanged', (data: any) => {
+      emit('transactionStateChanged', data);
     });
   };
 

--- a/src/entity/chat/model/__tests__/useMessageSync.test.ts
+++ b/src/entity/chat/model/__tests__/useMessageSync.test.ts
@@ -599,6 +599,99 @@ describe('useMessageSync', () => {
     });
   });
 
+  describe('handleTransactionStateChanged', () => {
+    const ROOM_DATA_KEY = ['chatRoomData', ROOM_ID];
+
+    it('현재 roomId와 일치하면 product.isCompleted를 업데이트한다', async () => {
+      const { result, queryClient } = await renderSync();
+      queryClient.setQueryData(ROOM_DATA_KEY, { product: { id: 1, isCompleted: false } });
+
+      act(() => {
+        result.current.handleTransactionStateChanged({
+          roomId: ROOM_ID,
+          productId: 1,
+          isCompleted: true,
+          createdAt: '2024-01-01T00:00:00Z',
+        });
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>(ROOM_DATA_KEY);
+      expect(cached?.product.isCompleted).toBe(true);
+    });
+
+    it('현재 roomId와 다르면 캐시를 변경하지 않는다', async () => {
+      const { result, queryClient } = await renderSync();
+      queryClient.setQueryData(ROOM_DATA_KEY, { product: { id: 1, isCompleted: false } });
+
+      act(() => {
+        result.current.handleTransactionStateChanged({
+          roomId: 999,
+          productId: 1,
+          isCompleted: true,
+          createdAt: '2024-01-01T00:00:00Z',
+        });
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>(ROOM_DATA_KEY);
+      expect(cached?.product.isCompleted).toBe(false);
+    });
+
+    it('product가 null이면 캐시를 변경하지 않는다', async () => {
+      const { result, queryClient } = await renderSync();
+      queryClient.setQueryData(ROOM_DATA_KEY, { product: null });
+
+      act(() => {
+        result.current.handleTransactionStateChanged({
+          roomId: ROOM_ID,
+          productId: 1,
+          isCompleted: true,
+          createdAt: '2024-01-01T00:00:00Z',
+        });
+      });
+
+      const cached = queryClient.getQueryData<{ product: null }>(ROOM_DATA_KEY);
+      expect(cached?.product).toBeNull();
+    });
+
+    it('기존 createdAt이 없으면 payload의 createdAt을 설정한다', async () => {
+      const { result, queryClient } = await renderSync();
+      queryClient.setQueryData(ROOM_DATA_KEY, {
+        product: { id: 1, isCompleted: false, createdAt: null },
+      });
+
+      act(() => {
+        result.current.handleTransactionStateChanged({
+          roomId: ROOM_ID,
+          productId: 1,
+          isCompleted: true,
+          createdAt: '2024-06-01T00:00:00Z',
+        });
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>(ROOM_DATA_KEY);
+      expect(cached?.product.createdAt).toBe('2024-06-01T00:00:00Z');
+    });
+
+    it('기존 createdAt이 이미 있으면 payload의 createdAt으로 덮어쓰지 않는다', async () => {
+      const { result, queryClient } = await renderSync();
+      queryClient.setQueryData(ROOM_DATA_KEY, {
+        product: { id: 1, isCompleted: false, createdAt: '2024-01-01T00:00:00Z' },
+      });
+
+      act(() => {
+        result.current.handleTransactionStateChanged({
+          roomId: ROOM_ID,
+          productId: 1,
+          isCompleted: true,
+          createdAt: '2024-06-01T00:00:00Z',
+        });
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>(ROOM_DATA_KEY);
+      expect(cached?.product.createdAt).toBe('2024-01-01T00:00:00Z');
+    });
+  });
+
   describe('markRoomAsRead', () => {
     it('마지막 메시지로 markChatAsRead를 호출한다', async () => {
       mockMarkChatAsRead.mockResolvedValue(undefined);

--- a/src/entity/chat/model/__tests__/useMessageSync.test.ts
+++ b/src/entity/chat/model/__tests__/useMessageSync.test.ts
@@ -672,6 +672,44 @@ describe('useMessageSync', () => {
       expect(cached?.product.createdAt).toBe('2024-06-01T00:00:00Z');
     });
 
+    it('isCompleted=true이면 isCompletable을 false로 업데이트한다', async () => {
+      const { result, queryClient } = await renderSync();
+      queryClient.setQueryData(ROOM_DATA_KEY, {
+        product: { id: 1, isCompleted: false, isCompletable: true },
+      });
+
+      act(() => {
+        result.current.handleTransactionStateChanged({
+          roomId: ROOM_ID,
+          productId: 1,
+          isCompleted: true,
+          createdAt: '2024-01-01T00:00:00Z',
+        });
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>(ROOM_DATA_KEY);
+      expect(cached?.product.isCompletable).toBe(false);
+    });
+
+    it('isCompleted=false이면 기존 isCompletable을 유지한다', async () => {
+      const { result, queryClient } = await renderSync();
+      queryClient.setQueryData(ROOM_DATA_KEY, {
+        product: { id: 1, isCompleted: false, isCompletable: true },
+      });
+
+      act(() => {
+        result.current.handleTransactionStateChanged({
+          roomId: ROOM_ID,
+          productId: 1,
+          isCompleted: false,
+          createdAt: '2024-01-01T00:00:00Z',
+        });
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>(ROOM_DATA_KEY);
+      expect(cached?.product.isCompletable).toBe(true);
+    });
+
     it('기존 createdAt이 이미 있으면 payload의 createdAt으로 덮어쓰지 않는다', async () => {
       const { result, queryClient } = await renderSync();
       queryClient.setQueryData(ROOM_DATA_KEY, {

--- a/src/entity/chat/model/useChatRoomData.ts
+++ b/src/entity/chat/model/useChatRoomData.ts
@@ -14,7 +14,7 @@ export const useChatRoomData = ({ roomId, enabled = true }: UseChatRoomDataOptio
     queryFn: () => getChatRoomData(roomId),
     enabled: enabled && !!roomId,
     staleTime: 30 * 1000,
-    refetchInterval: 10 * 1000,
+    refetchInterval: 30 * 1000,
     refetchOnWindowFocus: false,
   });
 };

--- a/src/entity/chat/model/useChatRoomData.ts
+++ b/src/entity/chat/model/useChatRoomData.ts
@@ -14,6 +14,7 @@ export const useChatRoomData = ({ roomId, enabled = true }: UseChatRoomDataOptio
     queryFn: () => getChatRoomData(roomId),
     enabled: enabled && !!roomId,
     staleTime: 30 * 1000,
+    refetchInterval: 10 * 1000,
     refetchOnWindowFocus: false,
   });
 };

--- a/src/entity/chat/model/useChatSocket.ts
+++ b/src/entity/chat/model/useChatSocket.ts
@@ -33,6 +33,7 @@ export const useChatSocket = ({
     handleConnect: handleMessageSyncConnect,
     handleReceiveMessage,
     handleUpdateRoomList,
+    handleTransactionStateChanged,
     markRoomAsRead,
   } = useMessageSync({
     currentRoomId,
@@ -59,6 +60,7 @@ export const useChatSocket = ({
     onConnect: handleConnect,
     onReceiveMessage: handleReceiveMessage,
     onUpdateRoomList: handleUpdateRoomList,
+    onTransactionStateChanged: handleTransactionStateChanged,
   });
 
   useEffect(() => {

--- a/src/entity/chat/model/useMessageSync.ts
+++ b/src/entity/chat/model/useMessageSync.ts
@@ -7,6 +7,7 @@ import type { RoomId } from '@/shared/types/chatType';
 import { getCurrentUserId } from '~/shared/lib/getCurrentUserId';
 import { chatMessageKeys } from './chatQueryKeys';
 import { logger } from '~/shared/lib/logger';
+import type { TransactionStateChangedPayload } from '../lib/socketService';
 
 interface UseMessageSyncProps {
   currentRoomId?: RoomId;
@@ -163,6 +164,28 @@ export const useMessageSync = ({
     [queryClient, chatRoomQueryKey]
   );
 
+  const handleTransactionStateChanged = useCallback(
+    (data: TransactionStateChangedPayload) => {
+      if (!currentRoomId || data.roomId !== currentRoomId) return;
+
+      queryClient.setQueryData<{ product: Record<string, unknown> | null }>(
+        ['chatRoomData', currentRoomId],
+        (old) => {
+          if (!old?.product) return old;
+          return {
+            ...old,
+            product: {
+              ...old.product,
+              isCompleted: data.isCompleted,
+              ...(data.createdAt && !old.product.createdAt ? { createdAt: data.createdAt } : {}),
+            },
+          };
+        }
+      );
+    },
+    [queryClient, currentRoomId]
+  );
+
   const markRoomAsRead = useCallback(
     async (roomId: RoomId) => {
       if (!chatRoomQueryKey) return;
@@ -201,6 +224,7 @@ export const useMessageSync = ({
     handleConnect,
     handleReceiveMessage,
     handleUpdateRoomList,
+    handleTransactionStateChanged,
     markRoomAsRead,
   };
 };

--- a/src/entity/chat/model/useMessageSync.ts
+++ b/src/entity/chat/model/useMessageSync.ts
@@ -177,6 +177,7 @@ export const useMessageSync = ({
             product: {
               ...old.product,
               isCompleted: data.isCompleted,
+              isCompletable: data.isCompleted ? false : old.product.isCompletable,
               ...(data.createdAt && !old.product.createdAt ? { createdAt: data.createdAt } : {}),
             },
           };

--- a/src/entity/chat/model/useSocketEventHandlers.ts
+++ b/src/entity/chat/model/useSocketEventHandlers.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import type { IChatSocketService } from '../lib/socketService';
+import type { IChatSocketService, TransactionStateChangedPayload } from '../lib/socketService';
 import type { ChatMessageResponse } from './chatTypes';
 
 interface UseSocketEventHandlersProps {
@@ -12,6 +12,7 @@ interface UseSocketEventHandlersProps {
     lastMessageType: string;
     lastMessageTime: string;
   }) => void;
+  onTransactionStateChanged?: (data: TransactionStateChangedPayload) => void;
 }
 
 export const useSocketEventHandlers = ({
@@ -19,6 +20,7 @@ export const useSocketEventHandlers = ({
   onConnect,
   onReceiveMessage,
   onUpdateRoomList,
+  onTransactionStateChanged,
 }: UseSocketEventHandlersProps) => {
   useEffect(() => {
     if (onConnect) {
@@ -33,6 +35,10 @@ export const useSocketEventHandlers = ({
       socketService.on('updateRoomList', onUpdateRoomList);
     }
 
+    if (onTransactionStateChanged) {
+      socketService.on('transactionStateChanged', onTransactionStateChanged);
+    }
+
     return () => {
       if (onConnect) {
         socketService.off('connect', onConnect);
@@ -45,6 +51,10 @@ export const useSocketEventHandlers = ({
       if (onUpdateRoomList) {
         socketService.off('updateRoomList', onUpdateRoomList);
       }
+
+      if (onTransactionStateChanged) {
+        socketService.off('transactionStateChanged', onTransactionStateChanged);
+      }
     };
-  }, [socketService, onConnect, onReceiveMessage, onUpdateRoomList]);
+  }, [socketService, onConnect, onReceiveMessage, onUpdateRoomList, onTransactionStateChanged]);
 };

--- a/src/shared/lib/socket.ts
+++ b/src/shared/lib/socket.ts
@@ -109,6 +109,10 @@ class SocketManager implements ISocketManager {
     this.socket.on('updateRoomList', (...args) => {
       this.emit('updateRoomList', ...args);
     });
+
+    this.socket.on('transactionStateChanged', (...args) => {
+      this.emit('transactionStateChanged', ...args);
+    });
   }
 
   private handleConnectionError(error: Error): void {
@@ -137,6 +141,7 @@ class SocketManager implements ISocketManager {
     'disconnect',
     'receiveMessage',
     'updateRoomList',
+    'transactionStateChanged',
   ]);
 
   emit(event: string, ...args: any[]): void {

--- a/src/view/chat/ui/ChatRoomPage/index.tsx
+++ b/src/view/chat/ui/ChatRoomPage/index.tsx
@@ -2,6 +2,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Text, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
 import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { logger } from '~/shared/lib/logger';
 import { useChatMessages } from '~/widget/chat/model/useChatMessages';
 import { useChatAction } from '~/widget/chat/model/useChatActions';
@@ -21,6 +22,7 @@ import ReviewsModal from '~/entity/post/ui/ReviewsModal';
 export default function ChatRoomPage() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const roomId = Number(id) as RoomId;
+  const queryClient = useQueryClient();
 
   const [isTradeRequestModalVisible, setIsTradeRequestModalVisible] = useState(false);
   const [isReviewModalVisible, setIsReviewModalVisible] = useState(false);
@@ -52,6 +54,7 @@ export default function ChatRoomPage() {
     hasTradeRequest,
     shouldShowButtons,
   } = useTradeHandlers({
+    roomId,
     roomData: roomData || null,
     otherUserInfo,
   });
@@ -101,10 +104,11 @@ export default function ChatRoomPage() {
     try {
       await executeTradeRequest();
       setIsTradeRequestModalVisible(false);
+      queryClient.invalidateQueries({ queryKey: ['chatRoomData', roomId] });
     } catch (error) {
       logger.error('handleTradeRequest failed', error);
     }
-  }, [executeTradeRequest]);
+  }, [executeTradeRequest, queryClient, roomId]);
 
   const handleReviewSubmit = useCallback(
     async (light: number, contents: string) => {

--- a/src/widget/chat/model/__tests__/useChatUIState.test.ts
+++ b/src/widget/chat/model/__tests__/useChatUIState.test.ts
@@ -87,13 +87,13 @@ describe('useChatUIState', () => {
       expect(result.current.menuConfig.shouldShowMenuButton).toBe(true);
     });
 
-    it('productDetail.mode가 RECEIVER이면 isGiverMode가 false이다', () => {
+    it('productDetail.mode가 RECEIVER이면 isGiverMode가 false이고 shouldShowMenuButton이 true이다', () => {
       setupMocks({ productDetail: { mode: 'RECEIVER' } });
 
       const { result } = renderHookWithProviders(() => useChatUIState(defaultProps));
 
       expect(result.current.menuConfig.isGiverMode).toBe(false);
-      expect(result.current.menuConfig.shouldShowMenuButton).toBe(false);
+      expect(result.current.menuConfig.shouldShowMenuButton).toBe(true);
     });
 
     it('productDetail이 없으면 shouldShowMenuButton이 false이다', () => {

--- a/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
+++ b/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
@@ -35,7 +35,7 @@ describe('useTradeHandlers', () => {
   describe('hasTradeRequest', () => {
     it('product.createdAt이 있으면 hasTradeRequest가 true이다', () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       expect(result.current.hasTradeRequest).toBe(true);
@@ -43,7 +43,7 @@ describe('useTradeHandlers', () => {
 
     it('product.createdAt이 null이면 hasTradeRequest가 false이다', () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData({ createdAt: null }), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData({ createdAt: null }), otherUserInfo })
       );
 
       expect(result.current.hasTradeRequest).toBe(false);
@@ -51,7 +51,7 @@ describe('useTradeHandlers', () => {
 
     it('product가 null이면 hasTradeRequest가 false이다', () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: { product: null }, otherUserInfo })
       );
 
       expect(result.current.hasTradeRequest).toBe(false);
@@ -59,7 +59,7 @@ describe('useTradeHandlers', () => {
 
     it('roomData가 null이면 hasTradeRequest가 false이다', () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: null, otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: null, otherUserInfo })
       );
 
       expect(result.current.hasTradeRequest).toBe(false);
@@ -69,7 +69,11 @@ describe('useTradeHandlers', () => {
   describe('shouldShowButtons', () => {
     it('hasTradeRequest=true, isCompletable=true이면 shouldShowButtons가 true이다', () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData({ isCompletable: true }), otherUserInfo })
+        useTradeHandlers({
+          roomId: 1,
+          roomData: makeRoomData({ isCompletable: true }),
+          otherUserInfo,
+        })
       );
 
       expect(result.current.shouldShowButtons).toBe(true);
@@ -77,7 +81,11 @@ describe('useTradeHandlers', () => {
 
     it('isCompletable=false이면 shouldShowButtons가 false이다', () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData({ isCompletable: false }), otherUserInfo })
+        useTradeHandlers({
+          roomId: 1,
+          roomData: makeRoomData({ isCompletable: false }),
+          otherUserInfo,
+        })
       );
 
       expect(result.current.shouldShowButtons).toBe(false);
@@ -85,7 +93,7 @@ describe('useTradeHandlers', () => {
 
     it('createdAt이 null이면 shouldShowButtons가 false이다', () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData({ createdAt: null }), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData({ createdAt: null }), otherUserInfo })
       );
 
       expect(result.current.shouldShowButtons).toBe(false);
@@ -97,7 +105,7 @@ describe('useTradeHandlers', () => {
       mockRequestTrade.mockResolvedValue({});
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -114,7 +122,7 @@ describe('useTradeHandlers', () => {
       mockRequestTrade.mockRejectedValue(new Error('수락 실패'));
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -128,7 +136,11 @@ describe('useTradeHandlers', () => {
 
     it('otherUserInfo.id가 없으면 requestTrade를 호출하지 않는다', async () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo: { nickname: '상대방' } })
+        useTradeHandlers({
+          roomId: 1,
+          roomData: makeRoomData(),
+          otherUserInfo: { nickname: '상대방' },
+        })
       );
 
       await act(async () => {
@@ -140,7 +152,7 @@ describe('useTradeHandlers', () => {
 
     it('productId가 없으면 requestTrade를 호출하지 않는다', async () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: { product: null }, otherUserInfo })
       );
 
       await act(async () => {
@@ -156,7 +168,7 @@ describe('useTradeHandlers', () => {
       mockMakeReservation.mockResolvedValue({});
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -173,7 +185,7 @@ describe('useTradeHandlers', () => {
       mockMakeReservation.mockRejectedValue(new Error('예약 실패'));
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -187,7 +199,7 @@ describe('useTradeHandlers', () => {
 
     it('productId가 없으면 makeReservation을 호출하지 않는다', async () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: { product: null }, otherUserInfo })
       );
 
       await act(async () => {
@@ -203,7 +215,7 @@ describe('useTradeHandlers', () => {
       mockCancelReservation.mockResolvedValue({});
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -220,7 +232,7 @@ describe('useTradeHandlers', () => {
       mockCancelReservation.mockRejectedValue(new Error('취소 실패'));
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -234,7 +246,7 @@ describe('useTradeHandlers', () => {
 
     it('productId가 없으면 cancelReservation을 호출하지 않는다', async () => {
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: { product: null }, otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: { product: null }, otherUserInfo })
       );
 
       await act(async () => {
@@ -248,7 +260,7 @@ describe('useTradeHandlers', () => {
       mockCancelReservation.mockRejectedValue('string error');
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -269,7 +281,7 @@ describe('useTradeHandlers', () => {
       mockRequestTrade.mockRejectedValue('string error');
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {
@@ -288,7 +300,7 @@ describe('useTradeHandlers', () => {
       mockMakeReservation.mockRejectedValue('string error');
 
       const { result } = renderHookWithProviders(() =>
-        useTradeHandlers({ roomData: makeRoomData(), otherUserInfo })
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
       );
 
       await act(async () => {

--- a/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
+++ b/src/widget/chat/model/__tests__/useTradeHandlers.test.ts
@@ -118,6 +118,52 @@ describe('useTradeHandlers', () => {
       );
     });
 
+    it('성공 시 chatRoomData 캐시를 isCompleted=true, isCompletable=false로 즉시 업데이트한다', async () => {
+      mockRequestTrade.mockResolvedValue({});
+
+      const { result, queryClient } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
+      );
+
+      queryClient.setQueryData(['chatRoomData', 1], {
+        product: { id: 1, isCompleted: false, isCompletable: true },
+      });
+
+      await act(async () => {
+        await result.current.handleTradeAccept();
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>([
+        'chatRoomData',
+        1,
+      ]);
+      expect(cached?.product.isCompleted).toBe(true);
+      expect(cached?.product.isCompletable).toBe(false);
+    });
+
+    it('실패 시 캐시를 변경하지 않는다', async () => {
+      mockRequestTrade.mockRejectedValue(new Error('수락 실패'));
+
+      const { result, queryClient } = renderHookWithProviders(() =>
+        useTradeHandlers({ roomId: 1, roomData: makeRoomData(), otherUserInfo })
+      );
+
+      queryClient.setQueryData(['chatRoomData', 1], {
+        product: { id: 1, isCompleted: false, isCompletable: true },
+      });
+
+      await act(async () => {
+        await result.current.handleTradeAccept();
+      });
+
+      const cached = queryClient.getQueryData<{ product: Record<string, unknown> }>([
+        'chatRoomData',
+        1,
+      ]);
+      expect(cached?.product.isCompleted).toBe(false);
+      expect(cached?.product.isCompletable).toBe(true);
+    });
+
     it('실패 시 에러 Toast를 표시한다', async () => {
       mockRequestTrade.mockRejectedValue(new Error('수락 실패'));
 

--- a/src/widget/chat/model/useChatUIState.ts
+++ b/src/widget/chat/model/useChatUIState.ts
@@ -58,7 +58,8 @@ export const useChatUIState = ({
   const { data: productDetail, isLoading: isProductLoading } = useGetItem(productId);
 
   const isGiverMode = productDetail?.mode === MODE.GIVER;
-  const shouldShowMenuButton = !isProductLoading && isGiverMode;
+  const isReceiverMode = productDetail?.mode === MODE.RECEIVER;
+  const shouldShowMenuButton = !isProductLoading && (isGiverMode || isReceiverMode);
 
   const tradeEmbedConfig = useMemo(
     () => ({

--- a/src/widget/chat/model/useTradeHandlers.ts
+++ b/src/widget/chat/model/useTradeHandlers.ts
@@ -1,10 +1,13 @@
 import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
 import { requestTrade } from '~/entity/post/api/requestTrade';
 import { makeReservation } from '~/entity/post/api/makeReservation';
 import { cancelReservation } from '~/entity/post/api/cancelReservation';
+import type { RoomId } from '~/shared/types/chatType';
 
 interface UseTradeHandlersParams {
+  readonly roomId: RoomId;
   readonly roomData: {
     readonly product?: {
       readonly id: number;
@@ -24,9 +27,11 @@ interface UseTradeHandlersReturn {
 }
 
 export const useTradeHandlers = ({
+  roomId,
   roomData,
   otherUserInfo,
 }: UseTradeHandlersParams): UseTradeHandlersReturn => {
+  const queryClient = useQueryClient();
   const hasTradeRequest =
     roomData?.product?.createdAt !== null && roomData?.product?.createdAt !== undefined;
 
@@ -41,6 +46,17 @@ export const useTradeHandlers = ({
         otherMemberId: otherUserInfo.id,
       });
 
+      queryClient.setQueryData<{ product: Record<string, unknown> | null }>(
+        ['chatRoomData', roomId],
+        (old) => {
+          if (!old?.product) return old;
+          return {
+            ...old,
+            product: { ...old.product, isCompleted: true, isCompletable: false },
+          };
+        }
+      );
+
       Toast.show({
         type: 'success',
         text1: '거래가 수락되었습니다!',
@@ -52,7 +68,7 @@ export const useTradeHandlers = ({
         text2: error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
       });
     }
-  }, [roomData?.product?.id, otherUserInfo.id]);
+  }, [roomData?.product?.id, otherUserInfo.id, queryClient, roomId]);
 
   const handleReservation = useCallback(async () => {
     if (!roomData?.product?.id) return;


### PR DESCRIPTION
#306 
#307 

## 변경 사항

### 1. 거래 상태 실시간 동기화
판매자가 거래 요청을 보냈을 때 구매자 화면이 채팅방을 나갔다 들어와야 업데이트되는 문제를 수정했습니다.

백엔드의 `transactionStateChanged` 소켓 이벤트를 수신해 React Query 캐시를 즉시 업데이트하도록 처리했습니다.

- `SocketManager`에 `transactionStateChanged` 이벤트 리스너 추가 및 `RESERVED_EVENTS` 등록
- `socketService`, `useSocketEventHandlers`, `useChatSocket`에 이벤트 파이프라인 연결
- `useMessageSync`에서 수신 시 `setQueryData`로 캐시 직접 업데이트 (네트워크 요청 없음)
- 소켓 이벤트 누락에 대비해 `useChatRoomData`에 `refetchInterval: 10s` 폴백 추가

### 2. 거래 수락/요청 후 즉시 반영
- 거래 수락(`handleTradeAccept`) 성공 시 `setQueryData`로 즉시 캐시 업데이트
- 거래 요청(`handleTradeRequest`) 성공 시 `invalidateQueries`로 최신 상태 fetch

### 3. 물건.필요해요 채팅방 메뉴 버튼 노출
`MODE.GIVER`에만 노출되던 점 3개 메뉴 버튼을 `MODE.RECEIVER`에서도 표시하도록 수정했습니다.

## 테스트 방법
1. 물건.팔아요 게시글 채팅방 진입
2. 판매자가 거래 요청 전송 → 구매자 화면에 거래 embed 즉시 표시 확인
3. 구매자가 거래 완료 → 양측 리뷰 UI 즉시 표시 확인
4. 물건.필요해요 게시글 채팅방에서 우측 상단 점 3개 버튼 노출 확인
