### PR TITLE
fix: Sentry 계정 변경

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,7 +30,7 @@
         {
           "url": "https://sentry.io/",
           "project": "react-native",
-          "organization": "schoolcompany"
+          "organization": "gsmschool"
         }
       ]
     ],

--- a/ios/sentry.properties
+++ b/ios/sentry.properties
@@ -1,4 +1,4 @@
 defaults.url=https://sentry.io/
-defaults.org=schoolcompany
+defaults.org=gsmschool
 defaults.project=react-native
 # Using SENTRY_AUTH_TOKEN environment variable


### PR DESCRIPTION
## 변경 사항

- `ios/sentry.properties` org 변경 (`schoolcompany` → `gsmschool`)
- `.env` Sentry 관련 환경변수 4개 새 계정 값으로 교체
  - `EXPO_PUBLIC_SENTRY_DSN`
  - `SENTRY_ORG`
  - `SENTRY_PROJECT`
  - `SENTRY_AUTH_TOKEN`
- EAS Secrets (development / preview / production) 동일하게 업데이트
