### PR TITLE
chore: 버전 1.0.10 → 1.0.13 동기화

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "jsEngine": "hermes",
     "name": "시민화폐 광산",
     "slug": "my-expo-app",
-    "version": "1.0.10",
+    "version": "1.0.13",
     "scheme": "gwangsan",
     "web": {
       "favicon": "./src/app/favicon.ico"

--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.10</string>
+	<string>1.0.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
## 개요
main 브랜치와의 버전 충돌 해소를 위해 버전을 1.0.13으로 동기화합니다.

## 변경 사항
- `app.json` version: `1.0.10` → `1.0.13`
- `ios/app/Info.plist` CFBundleShortVersionString: `1.0.10` → `1.0.13`