### PR TITLE
fix: useMessageSync setQueryData 타입을 ChatRoomWithProduct로 수정

### DIFF
--- a/src/entity/chat/model/useMessageSync.ts
+++ b/src/entity/chat/model/useMessageSync.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { markChatAsRead } from '../api/markChatAsRead';
 import { useChatQueueStore } from '~/shared/store/useChatQueueStore';
-import type { ChatMessageResponse, ChatRoomListItem } from './chatTypes';
+import type { ChatMessageResponse, ChatRoomListItem, ChatRoomWithProduct } from './chatTypes';
 import type { RoomId } from '@/shared/types/chatType';
 import { getCurrentUserId } from '~/shared/lib/getCurrentUserId';
 import { chatMessageKeys } from './chatQueryKeys';
@@ -168,21 +168,18 @@ export const useMessageSync = ({
     (data: TransactionStateChangedPayload) => {
       if (!currentRoomId || data.roomId !== currentRoomId) return;
 
-      queryClient.setQueryData<{ product: Record<string, unknown> | null }>(
-        ['chatRoomData', currentRoomId],
-        (old) => {
-          if (!old?.product) return old;
-          return {
-            ...old,
-            product: {
-              ...old.product,
-              isCompleted: data.isCompleted,
-              isCompletable: data.isCompleted ? false : old.product.isCompletable,
-              ...(data.createdAt && !old.product.createdAt ? { createdAt: data.createdAt } : {}),
-            },
-          };
-        }
-      );
+      queryClient.setQueryData<ChatRoomWithProduct>(['chatRoomData', currentRoomId], (old) => {
+        if (!old?.product) return old;
+        return {
+          ...old,
+          product: {
+            ...old.product,
+            isCompleted: data.isCompleted,
+            isCompletable: data.isCompleted ? false : old.product.isCompletable,
+            ...(data.createdAt && !old.product.createdAt ? { createdAt: data.createdAt } : {}),
+          },
+        };
+      });
     },
     [queryClient, currentRoomId]
   );


### PR DESCRIPTION
## 개요
`useMessageSync`의 `setQueryData` 제네릭 타입을 실제 쿼리 타입으로 교체합니다.

## 문제
`queryClient.setQueryData<{ product: Record<string, unknown> | null }>`로 타입을 지정해
`old.product.isCompletable`, `old.product.createdAt` 접근 시 `unknown` 타입 에러가 발생할 수 있었습니다.

## 해결
`ChatRoomWithProduct`로 교체해 product 필드 접근에 대한 타입 안전성을 확보합니다.