### PR TITLE
chore: bump version to 1.0.15 (build 54)

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "jsEngine": "hermes",
     "name": "시민화폐 광산",
     "slug": "my-expo-app",
-    "version": "1.0.13",
+    "version": "1.0.15",
     "scheme": "gwangsan",
     "web": {
       "favicon": "./src/app/favicon.ico"
@@ -48,7 +48,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "kr.hs.gsm.gwangsan",
-      "buildNumber": "52",
+      "buildNumber": "55",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSPhotoLibraryUsageDescription": "거래 게시글 업로드 및 채팅에 사용할 이미지 업로드를 위해 저장공간에 접근합니다.",
@@ -63,7 +63,7 @@
       },
       "package": "gwangsan.io.kr",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 52
+      "versionCode": 55
     },
     "extra": {
       "eas": {

--- a/app.json
+++ b/app.json
@@ -48,7 +48,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "kr.hs.gsm.gwangsan",
-      "buildNumber": "55",
+      "buildNumber": "54",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSPhotoLibraryUsageDescription": "거래 게시글 업로드 및 채팅에 사용할 이미지 업로드를 위해 저장공간에 접근합니다.",
@@ -63,7 +63,7 @@
       },
       "package": "gwangsan.io.kr",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 55
+      "versionCode": 54
     },
     "extra": {
       "eas": {

--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.13</string>
+	<string>1.0.15</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -39,7 +39,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>52</string>
+	<string>54</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- `version`: 1.0.13 → 1.0.15
- iOS `buildNumber`: 52 → 54
- Android `versionCode`: 52 → 54

## Why
Google Play Console에서는 1.0.14 (53)이 올라가 있어 iOS 버전과 맞추기 위해 1.0.15 (54)로 통일했습니다.
