### PR TITLE
fix: prevent concurrent CD version bump push conflict

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ['main']
 
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -23,6 +27,9 @@ jobs:
 
       - name: Bump versionCode
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git pull --rebase
           CURRENT=$(node -p "require('./app.json').expo.android?.versionCode ?? 0")
           NEW=$((CURRENT + 1))
           node -e "
@@ -31,12 +38,13 @@ jobs:
             app.expo.android.versionCode = $NEW;
             fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
           "
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add app.json
           git commit -m "chore: bump versionCode to $NEW [skip ci]"
-          git pull --rebase
-          git push
+          for i in 1 2 3; do
+            git push && break
+            echo "Push failed, retrying ($i/3)..."
+            git pull --rebase
+          done
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ios_cd.yml
+++ b/.github/workflows/ios_cd.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ['main']
 
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -23,6 +27,9 @@ jobs:
 
       - name: Bump patch version
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git pull --rebase
           CURRENT=$(node -p "require('./app.json').expo.version")
           NEW=$(echo $CURRENT | awk -F. '{print $1"."$2"."$3+1}')
           node -e "
@@ -31,11 +38,13 @@ jobs:
             app.expo.version = '$NEW';
             fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
           "
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add app.json
           git commit -m "chore: bump version to $NEW [skip ci]"
-          git push
+          for i in 1 2 3; do
+            git push && break
+            echo "Push failed, retrying ($i/3)..."
+            git pull --rebase
+          done
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- `ios_cd`와 `android_cd`가 동시에 `main` push에 트리거되면 둘 다 app.json을 수정하고 push하려다 ref 충돌이 발생하는 레이스 컨디션 수정
- `concurrency: group: version-bump`으로 두 워크플로우를 직렬화 — 하나가 완료될 때까지 다른 하나 대기
- `git pull --rebase` 위치를 버전 읽기 이전으로 변경해 항상 최신 상태 기준으로 bump
- push 실패 시 rebase 후 최대 3회 재시도하는 루프 추가

## Test plan

- [ ] main에 push 후 `ios_cd`와 `android_cd` 두 워크플로우가 Actions 탭에서 queued → 순차 실행되는지 확인
- [ ] 실행 완료 후 app.json의 `version`과 `versionCode`가 각각 1씩 증가했는지 확인
- [ ] 두 bump 커밋이 main에 정상적으로 push되고 충돌 없이 이력이 쌓이는지 확인