### PR TITLE
chore: enable autoIncrement for iOS submit in eas.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "jsEngine": "hermes",
     "name": "시민화폐 광산",
     "slug": "my-expo-app",
-    "version": "1.0.15",
+    "version": "1.0.20",
     "scheme": "gwangsan",
     "web": {
       "favicon": "./src/app/favicon.ico"
@@ -48,7 +48,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "kr.hs.gsm.gwangsan",
-      "buildNumber": "54",
+      "buildNumber": "60",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSPhotoLibraryUsageDescription": "거래 게시글 업로드 및 채팅에 사용할 이미지 업로드를 위해 저장공간에 접근합니다.",
@@ -63,7 +63,7 @@
       },
       "package": "gwangsan.io.kr",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 54
+      "versionCode": 60
     },
     "extra": {
       "eas": {

--- a/eas.json
+++ b/eas.json
@@ -45,6 +45,9 @@
       "env": {
         "NODE_ENV": "production",
         "SENTRY_DISABLE_AUTO_UPLOAD": "true"
+      },
+      "ios": {
+        "autoIncrement": true
       }
     }
   },
@@ -52,8 +55,7 @@
     "production": {
       "ios": {
         "ascAppId": "6758655368",
-        "appleTeamId": "UB2797YAAH",
-        "autoIncrement": true
+        "appleTeamId": "UB2797YAAH"
       }
     }
   }

--- a/eas.json
+++ b/eas.json
@@ -52,7 +52,8 @@
     "production": {
       "ios": {
         "ascAppId": "6758655368",
-        "appleTeamId": "UB2797YAAH"
+        "appleTeamId": "UB2797YAAH",
+        "autoIncrement": true
       }
     }
   }

--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.15</string>
+	<string>1.0.20</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -39,7 +39,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>54</string>
+	<string>60</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary

- `eas.json`의 `submit.production.ios`에 `autoIncrement: true` 추가
- 기존에는 `eas submit` 시 빌드 번호를 수동으로 올려야 했으나, 이제 App Store Connect의 최신 빌드 번호를 기준으로 자동 증가하여 휴먼 에러 방지

## Test plan

- [ ] `eas submit --platform ios` 실행 후 빌드 번호가 App Store Connect 최신값보다 1 높게 자동 설정되는지 확인
- [ ] 동일 버전으로 중복 제출 시 빌드 번호 충돌 에러가 발생하지 않는지 확인