### PR TITLE
chore: migrate to EAS remote version management

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches: ['main']
 
-concurrency:
-  group: version-bump
-  cancel-in-progress: false
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -24,27 +20,6 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-
-      - name: Bump versionCode
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase
-          CURRENT=$(node -p "require('./app.json').expo.android?.versionCode ?? 0")
-          NEW=$((CURRENT + 1))
-          node -e "
-            const fs = require('fs');
-            const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
-            app.expo.android.versionCode = $NEW;
-            fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
-          "
-          git add app.json
-          git commit -m "chore: bump versionCode to $NEW [skip ci]"
-          for i in 1 2 3; do
-            git push && break
-            echo "Push failed, retrying ($i/3)..."
-            git pull --rebase
-          done
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ios_cd.yml
+++ b/.github/workflows/ios_cd.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches: ['main']
 
-concurrency:
-  group: version-bump
-  cancel-in-progress: false
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -24,27 +20,6 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-
-      - name: Bump patch version
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase
-          CURRENT=$(node -p "require('./app.json').expo.version")
-          NEW=$(echo $CURRENT | awk -F. '{print $1"."$2"."$3+1}')
-          node -e "
-            const fs = require('fs');
-            const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
-            app.expo.version = '$NEW';
-            fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
-          "
-          git add app.json
-          git commit -m "chore: bump version to $NEW [skip ci]"
-          for i in 1 2 3; do
-            git push && break
-            echo "Push failed, retrying ($i/3)..."
-            git pull --rebase
-          done
 
       - name: Install dependencies
         run: |

--- a/eas.json
+++ b/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.13.3",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {
@@ -47,6 +47,9 @@
         "SENTRY_DISABLE_AUTO_UPLOAD": "true"
       },
       "ios": {
+        "autoIncrement": true
+      },
+      "android": {
         "autoIncrement": true
       }
     }


### PR DESCRIPTION
## Summary

- `appVersionSource`를 `"local"` → `"remote"`로 변경해 빌드번호를 EAS 서버에서 관리하도록 전환
- iOS/Android production 프로파일에 `autoIncrement: true` 추가 — main 푸시마다 빌드번호(60→61→62...)가 자동 증가
- CD 워크플로우에서 app.json을 직접 수정하고 git push하던 "Bump patch version" / "Bump versionCode" 스텝 제거 — 이로 인한 push 경쟁 조건도 함께 해소
- `concurrency: version-bump` 그룹 제거 — 더 이상 CD에서 git push가 없으므로 불필요

## Test plan

- [ ] main 브랜치에 푸시 후 iOS CD / Android CD 워크플로우가 정상 완료되는지 확인
- [ ] EAS 빌드 완료 후 App Store Connect / Google Play Console에서 빌드번호가 61로 올라왔는지 확인
- [ ] app.json의 `buildNumber` / `versionCode` 필드가 더 이상 CD에 의해 변경되지 않는지 확인