### PR TITLE
fix: 안드로이드 키보드가 입력창을 가리는 문제 해결

### DIFF
--- a/__mocks__/react-native-keyboard-controller.js
+++ b/__mocks__/react-native-keyboard-controller.js
@@ -1,7 +1,7 @@
 const React = require('react');
+const { View } = require('react-native');
 
-const KeyboardAvoidingView = ({ children, ...props }) =>
-  React.createElement('View', props, children);
+const KeyboardAvoidingView = ({ children, ...props }) => React.createElement(View, props, children);
 
 const KeyboardProvider = ({ children }) => children;
 

--- a/__mocks__/react-native-keyboard-controller.js
+++ b/__mocks__/react-native-keyboard-controller.js
@@ -1,0 +1,21 @@
+const React = require('react');
+
+const KeyboardAvoidingView = ({ children, ...props }) =>
+  React.createElement('View', props, children);
+
+const KeyboardProvider = ({ children }) => children;
+
+const useKeyboardHandler = () => {};
+const useKeyboardContext = () => ({ height: { value: 0 } });
+const useReanimatedKeyboardAnimation = () => ({
+  height: { value: 0 },
+  progress: { value: 0 },
+});
+
+module.exports = {
+  KeyboardAvoidingView,
+  KeyboardProvider,
+  useKeyboardHandler,
+  useKeyboardContext,
+  useReanimatedKeyboardAnimation,
+};

--- a/app.json
+++ b/app.json
@@ -13,7 +13,6 @@
     },
     "plugins": [
       "expo-router",
-      "react-native-keyboard-controller",
       [
         "expo-local-authentication",
         {

--- a/app.json
+++ b/app.json
@@ -63,7 +63,8 @@
       },
       "package": "gwangsan.io.kr",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 60
+      "versionCode": 60,
+      "softwareKeyboardLayoutMode": "pan"
     },
     "extra": {
       "eas": {

--- a/app.json
+++ b/app.json
@@ -63,8 +63,7 @@
       },
       "package": "gwangsan.io.kr",
       "googleServicesFile": "./google-services.json",
-      "versionCode": 60,
-      "softwareKeyboardLayoutMode": "pan"
+      "versionCode": 60
     },
     "extra": {
       "eas": {

--- a/app.json
+++ b/app.json
@@ -13,6 +13,7 @@
     },
     "plugins": [
       "expo-router",
+      "react-native-keyboard-controller",
       [
         "expo-local-authentication",
         {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2103,7 +2103,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-keyboard-controller (1.21.9):
+  - react-native-keyboard-controller (1.18.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2121,7 +2121,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.21.9)
+    - react-native-keyboard-controller/common (= 1.18.5)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2132,7 +2132,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-keyboard-controller/common (1.21.9):
+  - react-native-keyboard-controller/common (1.18.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3681,7 +3681,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 017336879e2e0fb7537bbc08c24f34e2384c9260
   React-microtasksnativemodule: 63ee6730cec233feab9cdcc0c100dc28a12e4165
   react-native-image-picker: 6051cfd030121b880a58f1cc0e5e33e9887804e4
-  react-native-keyboard-controller: 5f328d63a149f6b89bf106ee755b64bf04d9d797
+  react-native-keyboard-controller: c4ca61f44d66c2f8987a7e67e9b78e80dc965c45
   react-native-netinfo: 9fad4eedfec9840a10e73ac4591ea1158523309b
   react-native-pager-view: 0e228ec2dfdd87807d125c7bbfb83299edede19c
   react-native-safe-area-context: 0a3b034bb63a5b684dd2f5fffd3c90ef6ed41ee8

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2103,6 +2103,63 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - react-native-keyboard-controller (1.21.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - react-native-keyboard-controller/common (= 1.21.9)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-keyboard-controller/common (1.21.9):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - react-native-netinfo (12.0.1):
     - boost
     - DoubleConversion
@@ -3204,6 +3261,7 @@ PODS:
     - SDWebImage/Core (~> 5.17)
   - Sentry/HybridSDK (8.56.1)
   - SocketRocket (0.7.1)
+  - TrustKit (2.0.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -3273,6 +3331,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
+  - react-native-keyboard-controller (from `../node_modules/react-native-keyboard-controller`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-pager-view (from `../node_modules/react-native-pager-view`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -3316,12 +3375,11 @@ DEPENDENCIES:
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - RNWorklets (from `../node_modules/react-native-worklets`)
   - SocketRocket (~> 0.7.1)
+  - TrustKit (~> 2.0)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - Sentry
-  trunk:
     - libavif
     - libdav1d
     - libwebp
@@ -3329,7 +3387,9 @@ SPEC REPOS:
     - SDWebImageAVIFCoder
     - SDWebImageSVGCoder
     - SDWebImageWebPCoder
+    - Sentry
     - SocketRocket
+    - TrustKit
 
 EXTERNAL SOURCES:
   boost:
@@ -3463,6 +3523,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
+  react-native-keyboard-controller:
+    :path: "../node_modules/react-native-keyboard-controller"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-pager-view:
@@ -3619,6 +3681,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 017336879e2e0fb7537bbc08c24f34e2384c9260
   React-microtasksnativemodule: 63ee6730cec233feab9cdcc0c100dc28a12e4165
   react-native-image-picker: 6051cfd030121b880a58f1cc0e5e33e9887804e4
+  react-native-keyboard-controller: 5f328d63a149f6b89bf106ee755b64bf04d9d797
   react-native-netinfo: 9fad4eedfec9840a10e73ac4591ea1158523309b
   react-native-pager-view: 0e228ec2dfdd87807d125c7bbfb83299edede19c
   react-native-safe-area-context: 0a3b034bb63a5b684dd2f5fffd3c90ef6ed41ee8
@@ -3667,8 +3730,9 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: b3ec44d01708fce73f99b544beb57e890eca4406
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
+  TrustKit: dad4c3a08248c21fcb9a3b5be3c2e2b9d4f9b973
   Yoga: cc4a6600d61e4e9276e860d4d68eebb834a050ba
 
-PODFILE CHECKSUM: 14fe4127d13262e51b72b38b0a63ae5a608cd7f1
+PODFILE CHECKSUM: df585d6f81ac497e738b06d58b3f1151b7831e5b
 
 COCOAPODS: 1.16.2

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^react-native-reanimated$': '<rootDir>/__mocks__/react-native-reanimated.js',
+    '^react-native-keyboard-controller$': '<rootDir>/__mocks__/react-native-keyboard-controller.js',
     '^~/test-utils$': '<rootDir>/src/test-utils/index.ts',
     '^@env$': '<rootDir>/src/mocks/env.ts',
     '^msw/node$': '<rootDir>/node_modules/msw/lib/node/index.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "react-native-dotenv": "^3.4.11",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-image-picker": "^8.2.1",
-        "react-native-keyboard-controller": "^1.21.9",
+        "react-native-keyboard-controller": "1.18.5",
         "react-native-keychain": "^10.0.0",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-pager-view": "6.9.1",
@@ -17734,9 +17734,9 @@
       }
     },
     "node_modules/react-native-keyboard-controller": {
-      "version": "1.21.9",
-      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.21.9.tgz",
-      "integrity": "sha512-+TkkFldht4+AXBQeDy1hLE7iqiW8/NkY/ekhcFsKIiRdI9qC5JDzx0TfAg1iYZB2IeOXppmURIy2jFCUjOcV1w==",
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.5.tgz",
+      "integrity": "sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==",
       "license": "MIT",
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-native-dotenv": "^3.4.11",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-image-picker": "^8.2.1",
+        "react-native-keyboard-controller": "^1.21.9",
         "react-native-keychain": "^10.0.0",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-pager-view": "6.9.1",
@@ -17730,6 +17731,20 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.21.9",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.21.9.tgz",
+      "integrity": "sha512-+TkkFldht4+AXBQeDy1hLE7iqiW8/NkY/ekhcFsKIiRdI9qC5JDzx0TfAg1iYZB2IeOXppmURIy2jFCUjOcV1w==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "node_modules/react-native-keychain": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-image-picker": "^8.2.1",
+    "react-native-keyboard-controller": "^1.21.9",
     "react-native-keychain": "^10.0.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-pager-view": "6.9.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-native-dotenv": "^3.4.11",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-image-picker": "^8.2.1",
-    "react-native-keyboard-controller": "^1.21.9",
+    "react-native-keyboard-controller": "1.18.5",
     "react-native-keychain": "^10.0.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-pager-view": "6.9.1",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,5 +1,6 @@
 import { Stack, usePathname, router } from 'expo-router';
 import { AppState, View } from 'react-native';
+import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { useEffect } from 'react';
 import { saveE2ECoverage } from '@/shared/lib/e2eCoverage';
 import '../../global.css';
@@ -63,21 +64,23 @@ export default function RootLayout() {
 
   if (!fontsLoaded) return null;
   return (
-    <View className="mb-6 flex-1 bg-white">
-      <QueryProvider>
-        <SentryRN.ErrorBoundary fallback={<></>}>
-          <Stack
-            screenOptions={{
-              headerShown: false,
-              animation: 'fade',
-              gestureEnabled: true,
-              gestureDirection: 'horizontal',
-            }}
-          />
-        </SentryRN.ErrorBoundary>
-        <Toast />
-        <NoNetworkOverlay visible={!isConnected} />
-      </QueryProvider>
-    </View>
+    <KeyboardProvider>
+      <View className="mb-6 flex-1 bg-white">
+        <QueryProvider>
+          <SentryRN.ErrorBoundary fallback={<></>}>
+            <Stack
+              screenOptions={{
+                headerShown: false,
+                animation: 'fade',
+                gestureEnabled: true,
+                gestureDirection: 'horizontal',
+              }}
+            />
+          </SentryRN.ErrorBoundary>
+          <Toast />
+          <NoNetworkOverlay visible={!isConnected} />
+        </QueryProvider>
+      </View>
+    </KeyboardProvider>
   );
 }

--- a/src/entity/auth/ui/ResetPasswordForm/index.tsx
+++ b/src/entity/auth/ui/ResetPasswordForm/index.tsx
@@ -1,11 +1,5 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useResetPasswordStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -35,9 +29,7 @@ function ResetPasswordForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1 bg-white">
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/ResetPasswordForm/index.tsx
+++ b/src/entity/auth/ui/ResetPasswordForm/index.tsx
@@ -1,11 +1,4 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useResetPasswordStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -35,10 +28,7 @@ function ResetPasswordForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1 bg-white"
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/ResetPasswordForm/index.tsx
+++ b/src/entity/auth/ui/ResetPasswordForm/index.tsx
@@ -1,4 +1,11 @@
-import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+} from 'react-native';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useResetPasswordStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -28,7 +35,9 @@ function ResetPasswordForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/SigninForm/index.tsx
+++ b/src/entity/auth/ui/SigninForm/index.tsx
@@ -1,11 +1,5 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useSigninStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -35,9 +29,7 @@ function SigninForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1 bg-white">
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/SigninForm/index.tsx
+++ b/src/entity/auth/ui/SigninForm/index.tsx
@@ -1,4 +1,11 @@
-import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+} from 'react-native';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useSigninStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -28,7 +35,9 @@ function SigninForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/SigninForm/index.tsx
+++ b/src/entity/auth/ui/SigninForm/index.tsx
@@ -1,11 +1,4 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useSigninStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -35,10 +28,7 @@ function SigninForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1 bg-white"
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/SignupForm/index.tsx
+++ b/src/entity/auth/ui/SignupForm/index.tsx
@@ -1,11 +1,4 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useSignupStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -35,10 +28,7 @@ function SignupForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1 bg-white"
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/SignupForm/index.tsx
+++ b/src/entity/auth/ui/SignupForm/index.tsx
@@ -1,4 +1,11 @@
-import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+} from 'react-native';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useSignupStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -28,7 +35,9 @@ function SignupForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/entity/auth/ui/SignupForm/index.tsx
+++ b/src/entity/auth/ui/SignupForm/index.tsx
@@ -1,11 +1,5 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { Button } from '@/shared/ui/Button';
 import { ReactNode, memo } from 'react';
 import { useSignupStepNavigation } from '~/entity/auth/model/useAuthSelectors';
@@ -35,9 +29,7 @@ function SignupForm({
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1 bg-white">
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/view/chat/ui/ChatRoomPage/index.tsx
+++ b/src/view/chat/ui/ChatRoomPage/index.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Text, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
+import { Text, ActivityIndicator, KeyboardAvoidingView } from 'react-native';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { logger } from '~/shared/lib/logger';
@@ -168,10 +168,7 @@ export default function ChatRoomPage() {
         connectionState={connectionState}
       />
 
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1"
-        keyboardVerticalOffset={0}>
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
         <ChatRoomContent
           messages={messages}
           hasMessages={updatedComponentState.hasMessages}

--- a/src/view/chat/ui/ChatRoomPage/index.tsx
+++ b/src/view/chat/ui/ChatRoomPage/index.tsx
@@ -1,6 +1,6 @@
 import { useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Text, ActivityIndicator, KeyboardAvoidingView } from 'react-native';
+import { Text, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { logger } from '~/shared/lib/logger';
@@ -168,7 +168,9 @@ export default function ChatRoomPage() {
         connectionState={connectionState}
       />
 
-      <KeyboardAvoidingView behavior="padding" className="flex-1">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1">
         <ChatRoomContent
           messages={messages}
           hasMessages={updatedComponentState.hasMessages}

--- a/src/view/chat/ui/ChatRoomPage/index.tsx
+++ b/src/view/chat/ui/ChatRoomPage/index.tsx
@@ -1,6 +1,7 @@
 import { useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Text, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
+import { Text, ActivityIndicator } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { logger } from '~/shared/lib/logger';
@@ -168,9 +169,7 @@ export default function ChatRoomPage() {
         connectionState={connectionState}
       />
 
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1">
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
         <ChatRoomContent
           messages={messages}
           hasMessages={updatedComponentState.hasMessages}

--- a/src/view/editProfile/ui/editProfilePage/index.tsx
+++ b/src/view/editProfile/ui/editProfilePage/index.tsx
@@ -1,4 +1,5 @@
-import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { SpecialtiesDropdown } from '~/entity/auth';
 import { Button, Header, Input } from '~/shared/ui';
@@ -9,9 +10,7 @@ export default function EditProfilePageView() {
     <SafeAreaView className="flex-1 bg-white">
       <Header headerTitle="프로필 수정" />
 
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1">
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
         <ScrollView className="flex-1 px-6" contentContainerStyle={{ paddingBottom: 24 }}>
           <View className="mt-3 flex gap-5">
             <Input label="별칭" />

--- a/src/view/editProfile/ui/editProfilePage/index.tsx
+++ b/src/view/editProfile/ui/editProfilePage/index.tsx
@@ -1,4 +1,4 @@
-import { KeyboardAvoidingView, ScrollView, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { SpecialtiesDropdown } from '~/entity/auth';
 import { Button, Header, Input } from '~/shared/ui';
@@ -9,7 +9,9 @@ export default function EditProfilePageView() {
     <SafeAreaView className="flex-1 bg-white">
       <Header headerTitle="프로필 수정" />
 
-      <KeyboardAvoidingView behavior="padding" className="flex-1">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1">
         <ScrollView className="flex-1 px-6" contentContainerStyle={{ paddingBottom: 24 }}>
           <View className="mt-3 flex gap-5">
             <Input label="별칭" />

--- a/src/view/editProfile/ui/editProfilePage/index.tsx
+++ b/src/view/editProfile/ui/editProfilePage/index.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, View } from 'react-native';
+import { KeyboardAvoidingView, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { SpecialtiesDropdown } from '~/entity/auth';
 import { Button, Header, Input } from '~/shared/ui';
@@ -9,17 +9,19 @@ export default function EditProfilePageView() {
     <SafeAreaView className="flex-1 bg-white">
       <Header headerTitle="프로필 수정" />
 
-      <ScrollView className="flex-1 px-6" contentContainerStyle={{ paddingBottom: 100 }}>
-        <View className="mt-3 flex gap-5">
-          <Input label="별칭" />
-          <SpecialtiesDropdown items={[]} label="특기" />
-          <TextField label="자기소개" />
-        </View>
-      </ScrollView>
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
+        <ScrollView className="flex-1 px-6" contentContainerStyle={{ paddingBottom: 24 }}>
+          <View className="mt-3 flex gap-5">
+            <Input label="별칭" />
+            <SpecialtiesDropdown items={[]} label="특기" />
+            <TextField label="자기소개" />
+          </View>
+        </ScrollView>
 
-      <View className="absolute bottom-6 left-6 right-6">
-        <Button>수정</Button>
-      </View>
+        <View className="px-6 pb-6">
+          <Button>수정</Button>
+        </View>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }

--- a/src/view/findNickname/ui/FindNicknamePage/index.tsx
+++ b/src/view/findNickname/ui/FindNicknamePage/index.tsx
@@ -1,11 +1,4 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Input } from '@/shared/ui/Input';
 import { Button } from '@/shared/ui/Button';
@@ -84,10 +77,7 @@ export default function FindNicknamePage() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1"
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}>
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/view/findNickname/ui/FindNicknamePage/index.tsx
+++ b/src/view/findNickname/ui/FindNicknamePage/index.tsx
@@ -1,11 +1,5 @@
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  KeyboardAvoidingView,
-  ScrollView,
-  Platform,
-} from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Input } from '@/shared/ui/Input';
 import { Button } from '@/shared/ui/Button';
@@ -84,9 +78,7 @@ export default function FindNicknamePage() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1">
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/view/findNickname/ui/FindNicknamePage/index.tsx
+++ b/src/view/findNickname/ui/FindNicknamePage/index.tsx
@@ -1,4 +1,11 @@
-import { View, Text, TouchableOpacity, KeyboardAvoidingView, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  ScrollView,
+  Platform,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Input } from '@/shared/ui/Input';
 import { Button } from '@/shared/ui/Button';
@@ -77,7 +84,9 @@ export default function FindNicknamePage() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView behavior="padding" className="flex-1">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}

--- a/src/view/profile/ui/ProfileEditPage/index.tsx
+++ b/src/view/profile/ui/ProfileEditPage/index.tsx
@@ -1,4 +1,4 @@
-import { View, ScrollView, ActivityIndicator } from 'react-native';
+import { View, ScrollView, ActivityIndicator, KeyboardAvoidingView } from 'react-native';
 import { useState, useEffect } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header, Input, Button } from '~/shared/ui';
@@ -64,40 +64,42 @@ export default function ProfileEditPageView() {
     <SafeAreaView className="flex-1 bg-white">
       <Header headerTitle="내 정보 수정" />
 
-      <ScrollView className="flex-1 px-6 py-4" showsVerticalScrollIndicator={false}>
-        <View className="gap-6">
-          <Input
-            label="별칭"
-            placeholder="별칭을 입력해주세요"
-            value={nickname}
-            onChangeText={setNickname}
-            maxLength={20}
-          />
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
+        <ScrollView className="flex-1 px-6 py-4" showsVerticalScrollIndicator={false}>
+          <View className="gap-6">
+            <Input
+              label="별칭"
+              placeholder="별칭을 입력해주세요"
+              value={nickname}
+              onChangeText={setNickname}
+              maxLength={20}
+            />
 
-          <SpecialtiesDropdown
-            label="특기"
-            items={SPECIALTIES}
-            placeholder="특기를 선택해주세요"
-            selectedItems={specialties}
-            onSelect={setSpecialties}
-            allowCustomInput={true}
-          />
+            <SpecialtiesDropdown
+              label="특기"
+              items={SPECIALTIES}
+              placeholder="특기를 선택해주세요"
+              selectedItems={specialties}
+              onSelect={setSpecialties}
+              allowCustomInput={true}
+            />
 
-          <TextField
-            label="자기소개"
-            placeholder="자신을 소개해주세요"
-            value={description}
-            onChangeText={setDescription}
-            maxLength={300}
-          />
+            <TextField
+              label="자기소개"
+              placeholder="자신을 소개해주세요"
+              value={description}
+              onChangeText={setDescription}
+              maxLength={300}
+            />
+          </View>
+        </ScrollView>
+
+        <View className="px-6 pb-6">
+          <Button onPress={handleSubmit} disabled={!isFormValid || isSubmitting}>
+            {isSubmitting ? '수정 중...' : '수정'}
+          </Button>
         </View>
-      </ScrollView>
-
-      <View className="px-6 pb-6">
-        <Button onPress={handleSubmit} disabled={!isFormValid || isSubmitting}>
-          {isSubmitting ? '수정 중...' : '수정'}
-        </Button>
-      </View>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }

--- a/src/view/profile/ui/ProfileEditPage/index.tsx
+++ b/src/view/profile/ui/ProfileEditPage/index.tsx
@@ -1,4 +1,5 @@
-import { View, ScrollView, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, ScrollView, ActivityIndicator } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useState, useEffect } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header, Input, Button } from '~/shared/ui';
@@ -64,9 +65,7 @@ export default function ProfileEditPageView() {
     <SafeAreaView className="flex-1 bg-white">
       <Header headerTitle="내 정보 수정" />
 
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1">
+      <KeyboardAvoidingView behavior="padding" className="flex-1">
         <ScrollView className="flex-1 px-6 py-4" showsVerticalScrollIndicator={false}>
           <View className="gap-6">
             <Input

--- a/src/view/profile/ui/ProfileEditPage/index.tsx
+++ b/src/view/profile/ui/ProfileEditPage/index.tsx
@@ -1,4 +1,4 @@
-import { View, ScrollView, ActivityIndicator, KeyboardAvoidingView } from 'react-native';
+import { View, ScrollView, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
 import { useState, useEffect } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Header, Input, Button } from '~/shared/ui';
@@ -64,7 +64,9 @@ export default function ProfileEditPageView() {
     <SafeAreaView className="flex-1 bg-white">
       <Header headerTitle="내 정보 수정" />
 
-      <KeyboardAvoidingView behavior="padding" className="flex-1">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1">
         <ScrollView className="flex-1 px-6 py-4" showsVerticalScrollIndicator={false}>
           <View className="gap-6">
             <Input

--- a/src/view/write/itemForm/ui/ItemFormPage/index.tsx
+++ b/src/view/write/itemForm/ui/ItemFormPage/index.tsx
@@ -1,5 +1,12 @@
 import { useState, useCallback, useEffect } from 'react';
-import { ActivityIndicator, KeyboardAvoidingView, ScrollView, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
 import { logger } from '@/shared/lib/logger';
 import { Header } from '@/shared/ui';
 import {
@@ -154,7 +161,9 @@ const ItemFormPage = () => {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        className="flex-1 bg-white">
         <Header headerTitle="게시글" />
         <ItemFormProgressBar step={step} />
         <ScrollView

--- a/src/view/write/itemForm/ui/ItemFormPage/index.tsx
+++ b/src/view/write/itemForm/ui/ItemFormPage/index.tsx
@@ -1,12 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import {
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  Text,
-  View,
-} from 'react-native';
+import { ActivityIndicator, KeyboardAvoidingView, ScrollView, Text, View } from 'react-native';
 import { logger } from '@/shared/lib/logger';
 import { Header } from '@/shared/ui';
 import {
@@ -161,9 +154,7 @@ const ItemFormPage = () => {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        className="flex-1 bg-white">
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <Header headerTitle="게시글" />
         <ItemFormProgressBar step={step} />
         <ScrollView

--- a/src/view/write/itemForm/ui/ItemFormPage/index.tsx
+++ b/src/view/write/itemForm/ui/ItemFormPage/index.tsx
@@ -1,12 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
-import {
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  Text,
-  View,
-} from 'react-native';
+import { ActivityIndicator, ScrollView, Text, View } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { logger } from '@/shared/lib/logger';
 import { Header } from '@/shared/ui';
 import {
@@ -161,9 +155,7 @@ const ItemFormPage = () => {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        className="flex-1 bg-white">
+      <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <Header headerTitle="게시글" />
         <ItemFormProgressBar step={step} />
         <ScrollView


### PR DESCRIPTION
## Summary

- **Android에서 키보드가 입력 필드를 가리는 문제 수정** (issue #335)
  - 기존 `behavior="height"`가 Android의 `adjustResize`와 이중 적용되어 레이아웃이 잘못 조정되던 버그 수정
- **`react-native-keyboard-controller` 도입으로 부드러운 키보드 애니메이션 구현**
  - 기존 RN 기본 `KeyboardAvoidingView`는 Android에서 키보드 올라오는 속도와 동기화가 안 됨
  - 네이티브 frame-synchronized 애니메이션으로 iOS/Android 모두 키보드와 UI가 자연스럽게 연동
- **`KeyboardProvider`를 루트 레이아웃에 추가**하여 앱 전체에서 키보드 이벤트 처리 통합
- **누락된 화면에 `KeyboardAvoidingView` 추가** (editProfile, profile 수정 화면)
- `softwareKeyboardLayoutMode: "pan"` 제거 — 헤더가 화면 밖으로 밀려나는 Android 사이드 이펙트 방지

## Test plan

- [ ] Android: 로그인/회원가입 화면에서 입력 필드 탭 시 키보드가 필드를 가리지 않고 화면이 올라오는지 확인
- [ ] Android: 채팅 화면에서 키보드 올라올 때 입력창과 메시지 목록이 자연스럽게 이동하는지 확인
- [ ] Android: 키보드 올라오는 속도와 UI 이동 속도가 동기화되는지 확인 (버벅임 없음)
- [ ] iOS: 기존과 동일하게 키보드 회피 동작 정상 작동 확인
- [ ] Android: 헤더가 화면 밖으로 밀려나지 않는지 확인