### PR TITLE
fix: 교환 후기 작성 후 상대방에게 전달되지 않는 문제 수정

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -37,6 +37,10 @@ export default function RootLayout() {
       };
       if (data?.alertType === AlertType.CHTTING_REQUEST && data?.sourceId != null) {
         router.push(`/chatting/${data.sourceId}`);
+      } else if (data?.alertType === AlertType.TRADE_COMPLETE && data?.sourceId != null) {
+        router.push(`/post/${data.sourceId}?review=1`);
+      } else if (data?.alertType === AlertType.REVIEW && data?.sourceId != null) {
+        router.push(`/cancelTrade/${data.sourceId}`);
       }
     });
     return () => sub.remove();

--- a/src/app/test/reviews.tsx
+++ b/src/app/test/reviews.tsx
@@ -21,7 +21,7 @@ export default function Reviews() {
   }, []);
 
   const handleSubmitReport = useCallback(
-    (light: number, contents: string) => {
+    async (light: number, contents: string) => {
       console.log('=== 후기 제출 ===');
       console.log('밝기:', light);
       console.log('내용:', contents);

--- a/src/entity/post/ui/ReviewsModal/__tests__/index.test.tsx
+++ b/src/entity/post/ui/ReviewsModal/__tests__/index.test.tsx
@@ -45,7 +45,7 @@ jest.mock('~/shared/ui/Button', () => ({
 const defaultProps = {
   isVisible: true,
   onClose: jest.fn(),
-  onSubmit: jest.fn(),
+  onSubmit: jest.fn().mockResolvedValue(undefined),
   light: 60,
   setLight: jest.fn(),
   contents: '',
@@ -85,22 +85,14 @@ describe('ReviewsModal', () => {
   });
 
   it('내용이 있으면 "작성완료" 누를 때 onSubmit이 light와 내용으로 호출된다', () => {
-    const onSubmit = jest.fn();
-    const onClose = jest.fn();
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
     const { getByTestId } = render(
-      <ReviewsModal
-        {...defaultProps}
-        contents="좋은 거래였어요"
-        light={70}
-        onSubmit={onSubmit}
-        onClose={onClose}
-      />
+      <ReviewsModal {...defaultProps} contents="좋은 거래였어요" light={70} onSubmit={onSubmit} />
     );
 
     fireEvent.press(getByTestId('submit-button'));
 
     expect(onSubmit).toHaveBeenCalledWith(70, '좋은 거래였어요');
-    expect(onClose).toHaveBeenCalled();
   });
 
   it('내용을 입력하고 제출하면 입력한 내용이 onSubmit에 전달된다', () => {

--- a/src/entity/post/ui/ReviewsModal/index.tsx
+++ b/src/entity/post/ui/ReviewsModal/index.tsx
@@ -7,7 +7,7 @@ import { BottomSheetModalWrapper, ProgressBar } from '~/shared/ui';
 interface ReviewsModalProps {
   isVisible: boolean;
   onClose: () => void;
-  onSubmit: (type: number, contents: string) => void;
+  onSubmit: (type: number, contents: string) => Promise<void>;
   light: number;
   setLight: (v: number) => void;
   contents: string;
@@ -38,13 +38,11 @@ const ReviewsModal = ({
 
   const isDisabled = useMemo(() => localContents.trim().length === 0, [localContents]);
 
-  const handleSubmit = useCallback(() => {
+  const handleSubmit = useCallback(async () => {
     if (localContents.trim()) {
-      setLight(localLight);
-      onSubmit(localLight, localContents.trim());
-      onClose();
+      await onSubmit(localLight, localContents.trim());
     }
-  }, [localContents, localLight, onSubmit, onClose, setLight]);
+  }, [localContents, localLight, onSubmit]);
 
   const handleLightChange = useCallback((value: number) => {
     setLocalLight(value);

--- a/src/shared/ui/ProgressBar/index.tsx
+++ b/src/shared/ui/ProgressBar/index.tsx
@@ -35,6 +35,7 @@ const ProgressBar = ({ value, onChange, min = 0, max = 100, step = 1 }: Progress
       const clampedValue = Math.max(min, Math.min(max, steppedValue));
 
       setLocalValue(clampedValue);
+      onChangeRef.current(clampedValue);
     },
     [sliderWidth, min, max, step]
   );

--- a/src/view/chat/ui/ChatRoomPage/index.tsx
+++ b/src/view/chat/ui/ChatRoomPage/index.tsx
@@ -5,6 +5,7 @@ import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { logger } from '~/shared/lib/logger';
+import Toast from 'react-native-toast-message';
 import { useChatMessages } from '~/widget/chat/model/useChatMessages';
 import { useChatAction } from '~/widget/chat/model/useChatActions';
 import { useTradeHandlers } from '~/widget/chat/model/useTradeHandlers';
@@ -126,6 +127,11 @@ export default function ChatRoomPage() {
         setReviewContents('');
       } catch (error) {
         logger.error('리뷰 작성 실패', error);
+        Toast.show({
+          type: 'error',
+          text1: '리뷰 작성 실패',
+          text2: '잠시 후 다시 시도해주세요.',
+        });
       }
     },
     [roomData?.product?.id]

--- a/src/widget/notification/ui/NotificationItem/index.tsx
+++ b/src/widget/notification/ui/NotificationItem/index.tsx
@@ -72,6 +72,10 @@ const NotificationItem = ({
       router.push(`/post/${sourceId}?review=1`);
       return;
     }
+    if (alertType === AlertType.REVIEW && sourceId) {
+      router.push(`/cancelTrade/${sourceId}`);
+      return;
+    }
   };
 
   const getButtonText = () => {


### PR DESCRIPTION
## Summary

- `ProgressBar`에서 슬라이더 드래그 시 `onChange`가 호출되지 않아 light 값이 항상 60으로 고정되어 전송되던 버그 수정
- `_layout.tsx` 푸시 알림 핸들러에 `TRADE_COMPLETE`, `REVIEW` 케이스 누락으로 앱이 백그라운드 상태일 때 알림 탭 시 화면 이동이 되지 않던 문제 수정
- `NotificationItem`에서 `REVIEW` 타입 인앱 알림 탭 시 아무 동작도 하지 않던 문제 수정 — 상대방이 후기를 확인할 수 없었던 핵심 원인
- `ChatRoomPage` 리뷰 작성 실패 시 에러 로그만 남기고 사용자에게 피드백이 없던 문제 수정

> 백엔드 constraint 버그(plusLight 상한 미처리)는 [Server PR #330](https://github.com/School-of-Company/Gwangsan-Server/pull/330)에서 수정 완료

## Test plan

- [ ] 채팅방에서 거래 완료 후 후기 작성 모달의 슬라이더를 조절했을 때 제출되는 light 값이 실제 슬라이더 위치와 일치하는지 확인
- [ ] 앱이 백그라운드 상태에서 `TRADE_COMPLETE` 푸시 알림 수신 후 탭했을 때 `/post/{id}?review=1` 화면으로 이동하는지 확인
- [ ] 후기 작성 완료 후 상대방 기기에 `REVIEW` 푸시 알림이 오고, 탭했을 때 후기 상세 화면으로 이동하는지 확인
- [ ] 알림 목록에서 `REVIEW` 타입 인앱 알림 탭 시 후기 상세 화면으로 이동하는지 확인
- [ ] 리뷰 작성 실패 시 에러 토스트가 표시되는지 확인