### PR TITLE
fix: Podfile.lock 동기화 시 push 실패 방지

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -100,7 +100,9 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add ios/Podfile.lock
             git commit -m "chore: sync Podfile.lock [skip ci]"
-            git push origin HEAD:$BRANCH
+            git fetch origin "$BRANCH"
+            git rebase "origin/$BRANCH"
+            git push origin HEAD:"$BRANCH"
           fi
 
       - name: Create placeholder GoogleService-Info.plist


### PR DESCRIPTION
## Summary

- `test-ios.yml`에서 `pod install` 후 Podfile.lock을 커밋·푸시하는 단계에서,
  체크아웃 이후 원격 브랜치에 다른 커밋이 쌓인 경우 non-fast-forward 오류로 푸시가 실패하는 문제 수정
- 푸시 전 `git fetch` + `git rebase`를 추가해 원격 최신 상태 위에 커밋을 얹은 뒤 푸시하도록 변경

## Test plan

- [ ] PR에 `test-ios` 워크플로우를 트리거한 뒤, Podfile.lock 변경이 발생하는 케이스에서 `Sync Podfile.lock to repo` 스텝이 성공(exit 0)으로 완료되는지 확인
- [ ] 동일 브랜치에 다른 커밋이 먼저 푸시된 상태에서도 `! [rejected]` 오류 없이 정상 푸시되는지 확인
- [ ] Podfile.lock 변경이 없는 경우 `"unchanged, skipping"` 메시지만 출력되고 스텝이 종료되는지 확인\