### PR TITLE
fix: Podfile.lock 동기화 후 rebase 전 dirty worktree 정리

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -101,6 +101,7 @@ jobs:
             git add ios/Podfile.lock
             git commit -m "chore: sync Podfile.lock [skip ci]"
             git fetch origin "$BRANCH"
+            git restore .
             git rebase "origin/$BRANCH"
             git push origin HEAD:"$BRANCH"
           fi


### PR DESCRIPTION
## Summary

- `pod install`은 `Podfile.lock` 외에도 `.xcworkspace` 매니페스트 등 부가 파일을 수정함
- 기존 스크립트는 `Podfile.lock`만 커밋하고 나머지 변경사항을 working tree에 남겨두었기 때문에 `git rebase`가 dirty worktree 오류로 실패함
- `git fetch` 이후, `git rebase` 이전에 `git restore .`를 추가해 불필요한 빌드 아티팩트 변경사항을 버리고 rebase가 정상 진행되도록 수정

## Test plan

- [ ] `test-ios.yml` 워크플로우를 PR에서 트리거했을 때 "Sync Podfile.lock to repo" 스텝이 exit code 1 없이 완료되는지 확인
- [ ] `Podfile.lock`이 실제로 변경된 경우, 해당 커밋이 브랜치에 정상 push되는지 확인
- [ ] `Podfile.lock`이 변경되지 않은 경우, "Podfile.lock unchanged, skipping" 메시지로 스텝을 건너뛰는지 확인