### PR TITLE
fix: iOS E2E CI 빌드 에러 가시화 및 실행 환경 고정

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -62,7 +62,6 @@ module.exports = {
         'CODE_SIGNING_ALLOWED=NO',
         'COMPILER_INDEX_STORE_ENABLE=NO',
         'GCC_GENERATE_DEBUGGING_SYMBOLS=NO',
-        '-quiet',
         'build',
       ].join(' '),
     },

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -38,7 +38,6 @@ module.exports = {
         'CODE_SIGN_IDENTITY=""',
         'CODE_SIGNING_REQUIRED=NO',
         'CODE_SIGNING_ALLOWED=NO',
-        '-quiet',
         'build',
       ].join(' '),
     },

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test-ios:
     name: iOS E2E Test (Detox)
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 120
     concurrency:
       group: ios-e2e-${{ github.event.pull_request.number || github.ref }}
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16'
+          xcode-version: '16.4'
 
       - name: Cache applesimutils
         id: cache-applesimutils
@@ -160,6 +160,15 @@ jobs:
             echo "enabled=true" >> $GITHUB_OUTPUT
           else
             echo "enabled=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Verify expo-modules-jsi patch applied
+        run: |
+          HEAD=$(head -1 node_modules/expo-modules-jsi/apple/Package.swift)
+          echo "Package.swift first line: $HEAD"
+          if [[ "$HEAD" != *"6.1"* ]]; then
+            echo "ERROR: swift-tools-version patch was not applied (expected 6.1, got: $HEAD)"
+            exit 1
           fi
 
       - name: Build app for Detox


### PR DESCRIPTION
## Summary

- `xcodebuild` 명령에서 `-quiet` 플래그 제거 — `expo-modules-jsi` xcframework 빌드 스크립트가 내부적으로 SPM을 실행하는데, `-quiet` 상태에서는 SPM 에러가 CI 로그에 노출되지 않아 `exit 1`만 보이고 원인 파악이 불가능했음
- `runs-on: macos-latest` → `macos-15` 고정 — 현재 `macos-latest` 러너에 iOS 26.x 시뮬레이터가 포함되기 시작해 환경 드리프트 위험이 있음
- `xcode-version: '16'` → `'16.4'` 고정 — `expo-modules-jsi@56.0.9`의 `Package.swift`가 `swift-tools-version: 6.2`를 선언하며, 기존 패치(`patches/expo-modules-jsi+56.0.9.patch`)가 6.1로 다운그레이드함. 6.1은 SPM 6.1을 처음 탑재한 Xcode 16.3+ 가 필요하므로 16.4로 명시
- 빌드 전 패치 검증 스텝 추가 — `patch-package`가 정상 적용됐는지 확인하고, 미적용 시 명확한 에러 메시지와 함께 즉시 실패

## Test plan

- [ ] CI에서 `test-ios.yml` 워크플로우 트리거 후 "Verify expo-modules-jsi patch applied" 스텝이 `swift-tools-version: 6.1` 확인 메시지를 출력하는지 확인
- [ ] 빌드 실패 시 xcodebuild 에러가 이전과 달리 CI 로그에 직접 출력되는지 확인
- [ ] Xcode 16.4 + macos-15 환경에서 Detox Release 빌드가 정상 완료되는지 확인
- [ ] 기존 E2E 테스트 전체가 통과하는지 확인