### PR TITLE
fix(e2e): signin next-button 가시성 확인을 whileElement scroll 방식으로 교체

### DIFF
--- a/e2e/signin.test.ts
+++ b/e2e/signin.test.ts
@@ -31,7 +31,8 @@ describe('로그인', () => {
 
     await waitFor(element(by.id('SigninForm-next-button')))
       .toBeVisible()
-      .withTimeout(3000);
+      .whileElement(by.id('SigninForm-scroll-view'))
+      .scroll(200, 'down');
     await element(by.id('SigninForm-next-button')).tap();
 
     // placeholder와 description이 동일하므로 input testID로 확인

--- a/e2e/signin.test.ts
+++ b/e2e/signin.test.ts
@@ -32,7 +32,7 @@ describe('로그인', () => {
     await waitFor(element(by.id('SigninForm-next-button')))
       .toBeVisible()
       .whileElement(by.id('SigninForm-scroll-view'))
-      .scroll(200, 'down');
+      .scroll(100, 'down');
     await element(by.id('SigninForm-next-button')).tap();
 
     // placeholder와 description이 동일하므로 input testID로 확인

--- a/src/entity/auth/ui/SigninForm/index.tsx
+++ b/src/entity/auth/ui/SigninForm/index.tsx
@@ -31,6 +31,7 @@ function SigninForm({
     <SafeAreaView className="flex-1 bg-white">
       <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
+          testID="SigninForm-scroll-view"
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}
           keyboardShouldPersistTaps="handled"


### PR DESCRIPTION
## Summary

- `typeText` 후 소프트 키보드가 올라온 상태에서 `SigninForm-next-button`이 키보드에 가려져 `toBeVisible()` 판정 실패 → `whileElement().scroll()` 패턴으로 교체해 키보드와 무관하게 버튼이 보일 때까지 ScrollView를 스크롤하도록 수정
- `detoxDisableSynchronization: 1` 환경에서 단순 타임아웃 연장은 키보드 가림 문제를 해결할 수 없어, Detox 공식 권장 방식인 `whileElement().scroll()` API를 채택
- `SigninForm` ScrollView에 `testID="SigninForm-scroll-view"` 추가 (테스트 앵커용, 앱 동작에 영향 없음)

## Test plan

- [ ] `npm run e2e:build:ios && npm run e2e:test:ios` — signin E2E 테스트 전체 통과 확인
- [ ] `별칭 입력 후 비밀번호 화면으로 이동한다` 케이스가 타임아웃 없이 통과하는지 확인
- [ ] 실기기/시뮬레이터에서 로그인 플로우 수동 진행 시 버튼 동작 이상 없는지 확인