### PR TITLE
fix(e2e): signin 테스트 키보드 가림 문제를 tapReturnKey 방식으로 해결

### DIFF
--- a/e2e/signin.test.ts
+++ b/e2e/signin.test.ts
@@ -27,7 +27,7 @@ describe('로그인', () => {
 
   it('별칭 입력 후 비밀번호 화면으로 이동한다', async () => {
     await element(by.id('NicknameStep-nickname-input')).tap();
-    await element(by.id('NicknameStep-nickname-input')).typeText('테스트');
+    await element(by.id('NicknameStep-nickname-input')).replaceText('테스트');
     // returnKeyType="next" + onSubmitEditing으로 키보드를 닫으면서 다음 단계로 이동
     await element(by.id('NicknameStep-nickname-input')).tapReturnKey();
 

--- a/e2e/signin.test.ts
+++ b/e2e/signin.test.ts
@@ -28,12 +28,8 @@ describe('로그인', () => {
   it('별칭 입력 후 비밀번호 화면으로 이동한다', async () => {
     await element(by.id('NicknameStep-nickname-input')).tap();
     await element(by.id('NicknameStep-nickname-input')).typeText('테스트');
-
-    await waitFor(element(by.id('SigninForm-next-button')))
-      .toBeVisible()
-      .whileElement(by.id('SigninForm-scroll-view'))
-      .scroll(100, 'down');
-    await element(by.id('SigninForm-next-button')).tap();
+    // returnKeyType="next" + onSubmitEditing으로 키보드를 닫으면서 다음 단계로 이동
+    await element(by.id('NicknameStep-nickname-input')).tapReturnKey();
 
     // placeholder와 description이 동일하므로 input testID로 확인
     await waitFor(element(by.id('PasswordStep-password-input')))

--- a/src/entity/auth/ui/SigninForm/index.tsx
+++ b/src/entity/auth/ui/SigninForm/index.tsx
@@ -31,7 +31,6 @@ function SigninForm({
     <SafeAreaView className="flex-1 bg-white">
       <KeyboardAvoidingView behavior="padding" className="flex-1 bg-white">
         <ScrollView
-          testID="SigninForm-scroll-view"
           className="flex-1"
           contentContainerStyle={{ flexGrow: 1 }}
           keyboardShouldPersistTaps="handled"


### PR DESCRIPTION
## Summary

- `contentContainerStyle={{ flexGrow: 1 }}` + `mt-auto` 구조로 인해 SigninForm의 ScrollView는 콘텐츠가 오버플로우되지 않아 스크롤 자체가 불가능 → `whileElement().scroll()` 방식이 근본적으로 작동할 수 없었음
- `detoxDisableSynchronization: 1` 환경에서 `react-native-keyboard-controller`의 `KeyboardAvoidingView`가 키보드 높이를 추적하지 못해 next 버튼이 키보드에 가려지는 문제가 실제 원인
- `whileElement().scroll()` 대신 `tapReturnKey()`를 사용해 `onSubmitEditing` 핸들러로 키보드를 닫으면서 다음 단계로 이동하도록 수정 — NicknameStep의 `returnKeyType="next"` 와 일치하는 자연스러운 사용자 흐름
- `whileElement().scroll()` 도입 시 추가했던 `SigninForm-scroll-view` testID 제거

## Test plan

- [ ] `npm run e2e:build:ios && npm run e2e:test:ios` — `별칭 입력 후 비밀번호 화면으로 이동한다` 케이스 타임아웃 없이 통과 확인
- [ ] `PasswordStep-password-input`이 5초 내 visible 판정되는지 확인
- [ ] 실기기에서 별칭 입력 후 Return 키 → 비밀번호 화면 이동 동작 확인