### PR TITLE
fix(eas): update iOS build image to macos-sequoia-15.6-xcode-16.4

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -48,7 +48,7 @@
       },
       "ios": {
         "autoIncrement": true,
-        "image": "macos-sequoia-15.6-xcode-16.1"
+        "image": "macos-sequoia-15.6-xcode-16.4"
       },
       "android": {
         "autoIncrement": true


### PR DESCRIPTION
## Summary

- `macos-sequoia-15.6-xcode-16.1` 이미지는 EAS 빌드 서버에 존재하지 않아 production iOS CD가 실패하고 있었음
- 동일한 macOS Sequoia 기반의 유효한 이미지인 `macos-sequoia-15.6-xcode-16.4`로 교체
- Expo SDK 56 / React Native 0.85 스택에는 최신 Xcode(16.4)가 더 적합함

## Test plan

- [ ] `ios_cd.yml` 워크플로우를 수동 트리거하여 EAS 빌드가 이미지 오류 없이 시작되는지 확인
- [ ] EAS 빌드 대시보드에서 `production` 프로파일 iOS 빌드가 정상 완료되는지 확인
- [ ] 생성된 `.ipa` 아카이브가 App Store Connect에 정상 업로드되는지 확인