### PR TITLE
fix: configure Android EAS submit and harden CD pipeline

### DIFF
--- a/.github/workflows/android_cd.yml
+++ b/.github/workflows/android_cd.yml
@@ -32,7 +32,12 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Create Google Play service account json
-        run: echo '${{ secrets.SERVICE_ACCOUNT_JSON }}' > service_account.json
+        run: |
+          echo '${{ secrets.SERVICE_ACCOUNT_JSON }}' > service_account.json
+          if [ ! -s service_account.json ]; then
+            echo "SERVICE_ACCOUNT_JSON secret is empty or missing"
+            exit 1
+          fi
 
       - name: EAS Build (Android)
         run: |

--- a/eas.json
+++ b/eas.json
@@ -60,6 +60,10 @@
       "ios": {
         "ascAppId": "6758655368",
         "appleTeamId": "UB2797YAAH"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./service_account.json",
+        "track": "production"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "expo-task-manager": "~56.0.18",
         "immer": "^10.1.3",
         "nativewind": "latest",
+        "patch-package": "^8.0.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
@@ -81,7 +82,6 @@
         "lint-staged": "^16.4.0",
         "msw": "^2.12.14",
         "nyc": "^18.0.0",
-        "patch-package": "^8.0.1",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.11",
         "react-test-renderer": "^19.1.0",
@@ -8309,7 +8309,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/abab": {
@@ -9461,7 +9460,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -9493,7 +9491,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10456,7 +10453,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -12996,7 +12992,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
@@ -13597,7 +13592,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -14566,7 +14560,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -16005,7 +15998,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
       "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -16044,7 +16036,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -16057,7 +16048,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -16092,7 +16082,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
@@ -17547,7 +17536,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18439,7 +18427,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18924,7 +18911,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
       "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
@@ -18954,7 +18940,6 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18970,7 +18955,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -18985,7 +18969,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -18998,7 +18981,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21261,7 +21243,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -22538,7 +22519,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -23022,7 +23002,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "scrolloop": "^0.3.4",
     "socket.io-client": "^4.8.1",
     "whatwg-fetch": "^3.6.20",
+    "patch-package": "^8.0.1",
     "zod": "^3.25.72",
     "zustand": "^5.0.6"
   },
@@ -102,7 +103,6 @@
     "lint-staged": "^16.4.0",
     "msw": "^2.12.14",
     "nyc": "^18.0.0",
-    "patch-package": "^8.0.1",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "react-test-renderer": "^19.1.0",

--- a/patches/expo-modules-jsi+56.0.9.patch
+++ b/patches/expo-modules-jsi+56.0.9.patch
@@ -80,7 +80,7 @@ diff --git a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/
 index a0e3e24..c06fa0c 100644
 --- a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
 +++ b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
-@@ -200,7 +200,7 @@
+@@ -200,6 +200,6 @@
        for propertyName in propertyNames {
          let propNameId = facebook.jsi.PropNameID.forUtf8(runtime.pointee, std.string(propertyName))
 -        vector.push_back(consuming: propNameId)
@@ -95,7 +95,7 @@ index a0e3e24..c06fa0c 100644
 -      _ arguments: consuming JavaScriptValuesBuffer,
 +      _ arguments: consuming JavaScriptValuesBuffer
      ) async throws -> JavaScriptValue
-
+ 
    /// Creates an asynchronous host function that runs given block when it's called.
 diff --git a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
 index 049acbb..89ea289 100644
@@ -227,7 +227,7 @@ index 9fffe5e..8cc1f18 100644
 -  internal weak let runtime: JavaScriptRuntime?
 +  internal weak var runtime: JavaScriptRuntime?
    internal let pointee: facebook.jsi.WeakObject
-
+ 
    /// Initializes a weak object with the underlying JSI weak object.
 diff --git a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
 index aaaaaaa..bbbbbbb 100644
@@ -235,7 +235,7 @@ index aaaaaaa..bbbbbbb 100644
 +++ b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
 @@ -1,21 +1,13 @@
  // swift-format-ignore-file: AlwaysUseLowerCamelCase
-
+ 
 -// `Task.immediate` is a pretty useful API that lets us immediately switch from synchronous to asynchronous context.
 -// Read the proposal for more: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0472-task-start-synchronously-on-caller-context.md
 -// Unfortunately, it is available only as of Apple OS 26.0 and there are no plans to backport it yet.
@@ -262,12 +262,12 @@ diff --git a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/incl
 index ccccccc..ddddddd 100644
 --- a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/RuntimeScheduler.h
 +++ b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/RuntimeScheduler.h
-@@ -51,11 +51,11 @@
+@@ -51,12 +51,12 @@
     */
 -  RuntimeScheduler(void *scheduler, ScheduleFn fn) noexcept
 +  RuntimeScheduler(void *scheduler, ScheduleFn fn) SWIFT_NAME(init(_:_:)) noexcept
        : nativeScheduler(scheduler), scheduleFn(fn) {}
-
+ 
    /**
     Constructs a no-op scheduler. Scheduled tasks run synchronously on the
     caller's thread — intended for standalone runtimes (e.g. tests) that have
@@ -275,29 +275,29 @@ index ccccccc..ddddddd 100644
     */
 -  RuntimeScheduler() {}
 +  RuntimeScheduler() SWIFT_NAME(init()) {}
-
+ 
    RuntimeScheduler(const RuntimeScheduler &) = delete;
 diff --git a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/NativeState.h b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/NativeState.h
 index eeeeeee..fffffff 100644
 --- a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/NativeState.h
 +++ b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/NativeState.h
-@@ -14,7 +14,7 @@
+@@ -14,6 +14,6 @@
  class NativeState final : public RetainedSwiftPointer, public facebook::jsi::NativeState {
  public:
 -  explicit NativeState(Context context, Deallocator deallocator) : RetainedSwiftPointer(context, deallocator) {}
 +  explicit NativeState(Context context, Deallocator deallocator) SWIFT_NAME(init(_:_:)) : RetainedSwiftPointer(context, deallocator) {}
-
+ 
    virtual ~NativeState() {
      _deallocator(_context);
 diff --git a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h
 index ggggggg..hhhhhhh 100644
 --- a/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h
 +++ b/node_modules/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h
-@@ -14,7 +14,7 @@
+@@ -14,6 +14,6 @@
  public:
    using Closure = facebook::jsi::Value(Context context, const facebook::jsi::Value *_Nonnull thisValue, const facebook::jsi::Value *_Nonnull args, size_t count);
-
+ 
 -  explicit HostFunctionClosure(Context context, Closure closure, Deallocator deallocator) : RetainedSwiftPointer(context, deallocator), _closure(closure) {};
 +  explicit HostFunctionClosure(Context context, Closure closure, Deallocator deallocator) SWIFT_NAME(init(_:_:_:)) : RetainedSwiftPointer(context, deallocator), _closure(closure) {};
-
+ 
    virtual ~HostFunctionClosure() {


### PR DESCRIPTION
## Summary

- `eas.json`에 Android 프로덕션 submit 설정(`serviceAccountKeyPath`, `track: production`) 추가 — iOS만 설정돼 있어 Android 스토어 배포가 누락되던 문제 해결
- `android_cd.yml`에 Google Play 서비스 계정 JSON 파일 생성 직후 유효성 검사 추가 — secret이 비어있거나 누락됐을 때 파이프라인 상단에서 조기 실패하도록 처리
- `patch-package`를 `devDependencies`에서 `dependencies`로 이동 — postinstall hook에서 실행되므로 프로덕션 의존성으로 있어야 EAS 빌드 컨테이너에서 패치가 올바르게 적용됨

## Test plan

- [ ] `eas submit --platform android --profile production`이 에러 없이 실행되고 Google Play 트랙에 업로드되는지 확인
- [ ] `SERVICE_ACCOUNT_JSON` secret을 의도적으로 비워두고 Android CD workflow를 트리거했을 때 "SERVICE_ACCOUNT_JSON secret is empty or missing" 메시지와 함께 early exit되는지 확인
- [ ] EAS 빌드 후 `postinstall`(`patch-package`) 이 빌드 컨테이너에서 정상 실행되어 patches/ 폴더의 패치가 적용되는지 확인