### PR TITLE
fix(ios): migrate to Xcode 26 & patch expo-modules-jsi Swift 6.x compat

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -48,7 +48,7 @@
       },
       "ios": {
         "autoIncrement": true,
-        "image": "macos-sequoia-15.6-xcode-16.4"
+        "image": "macos-tahoe-26.4-xcode-26.4"
       },
       "android": {
         "autoIncrement": true


### PR DESCRIPTION
## Summary

- **EAS iOS 빌드 이미지를 `macos-tahoe-26.4-xcode-26.4`로 전환**: Apple이 2026년 4월 28일부터 Xcode 26 이상으로 빌드된 앱만 App Store 제출을 허용하므로 불가피한 마이그레이션
- **`expo-modules-jsi@56.0.9` Swift 6.x 호환 패치 추가**: Swift 6.1/6.2에서 `explicit` C++ 생성자(`NativeState`, `RuntimeScheduler`, `HostFunctionClosure`)가 접근 불가로 빌드 실패하는 문제를 `SWIFT_NAME(init(...))` 어노테이션 추가로 수정
- **`expo-modules-core`, `react-native-reanimated`, `react-native-keyboard-controller`, `react-native-css-interop` 패치 추가**: SDK 56 (React Native 0.85.3) 업그레이드 후 발생한 upstream 호환성 문제 처리
- **`AppDelegate.swift` Swift 6.2 접근 제어 수정**: SE-0409로 인한 import 접근 레벨 오류 해결
- **CI 개선**: GitHub Actions 봇 커밋에서 lint/test 잡 스킵, Android CD에서 Google Play 서비스 계정 JSON 유효성 검사 추가, Xcode 빌드 `-quiet` 플래그 제거로 에러 가시성 확보
- **E2E 사인인 테스트 안정화**: 키보드 dismiss 방식을 `typeText` → `replaceText` + `tapReturnKey`로 교체하여 소형 기기 호환성 개선
- **SigninForm 키보드 처리 개선**: `KeyboardAvoidingView` → `KeyboardStickyView`로 교체하여 키보드 겹침 현상 해결

## Test plan

- [ ] EAS 빌드가 `macos-tahoe-26.4-xcode-26.4` 이미지로 성공적으로 완료되는지 확인
- [ ] 빌드 로그에 `patch-package` 실행 후 5개 패치가 모두 적용되었는지 확인 (`expo-modules-jsi`, `expo-modules-core`, `react-native-reanimated`, `react-native-keyboard-controller`, `react-native-css-interop`)
- [ ] App Store Connect에 `.ipa` 업로드가 Xcode 26 빌드로 허용되는지 확인
- [ ] iOS 기기에서 사인인 화면에서 키보드가 입력 필드를 가리지 않는지 확인
- [ ] E2E 사인인 테스트가 CI에서 통과하는지 확인 (`e2e:test:ios:release`)
- [ ] Android 빌드 및 Google Play 제출이 정상 동작하는지 확인
