### PR TITLE
fix: 인증 폼 하단 다음 버튼 여백 축소 (mb-8 → mb-2)

### DIFF
--- a/src/entity/auth/ui/ResetPasswordForm/index.tsx
+++ b/src/entity/auth/ui/ResetPasswordForm/index.tsx
@@ -50,7 +50,7 @@ function ResetPasswordForm({
 
             <View className="mt-8 flex-1">{children}</View>
 
-            <View className="mb-8 mt-auto">
+            <View className="mb-2 mt-auto">
               <Button onPress={onNext} disabled={isNextDisabled}>
                 {nextButtonText}
               </Button>

--- a/src/entity/auth/ui/SigninForm/index.tsx
+++ b/src/entity/auth/ui/SigninForm/index.tsx
@@ -52,7 +52,7 @@ function SigninForm({
       </ScrollView>
 
       <KeyboardStickyView>
-        <View className="mb-8 mt-4 px-6">
+        <View className="mb-2 mt-4 px-6">
           <Button testID="SigninForm-next-button" onPress={onNext} disabled={isNextDisabled}>
             {nextButtonText}
           </Button>

--- a/src/entity/auth/ui/SignupForm/index.tsx
+++ b/src/entity/auth/ui/SignupForm/index.tsx
@@ -50,7 +50,7 @@ function SignupForm({
 
             <View className="mt-8 flex-1">{children}</View>
 
-            <View className="mb-8 mt-auto">
+            <View className="mb-2 mt-auto">
               <Button onPress={onNext} disabled={isNextDisabled}>
                 {nextButtonText}
               </Button>

--- a/src/view/findNickname/ui/FindNicknamePage/index.tsx
+++ b/src/view/findNickname/ui/FindNicknamePage/index.tsx
@@ -68,7 +68,7 @@ export default function FindNicknamePage() {
             <Text className="text-center text-sm text-gray-500">별칭</Text>
             <Text className="mt-2 text-center text-2xl font-bold">{foundNickname}</Text>
           </View>
-          <View className="mb-8 mt-auto">
+          <View className="mb-4 mt-auto">
             <Button onPress={() => router.replace('/signin')}>로그인하러 가기</Button>
           </View>
         </View>
@@ -156,7 +156,7 @@ export default function FindNicknamePage() {
               )}
             </View>
 
-            <View className="mb-2 mt-auto">
+            <View className="mb-4 mt-auto">
               <Button onPress={handleFindNickname} disabled={!isVerificationComplete || isLoading}>
                 {isLoading ? '찾는 중...' : '별칭 찾기'}
               </Button>

--- a/src/view/findNickname/ui/FindNicknamePage/index.tsx
+++ b/src/view/findNickname/ui/FindNicknamePage/index.tsx
@@ -156,7 +156,7 @@ export default function FindNicknamePage() {
               )}
             </View>
 
-            <View className="mb-8 mt-auto">
+            <View className="mb-2 mt-auto">
               <Button onPress={handleFindNickname} disabled={!isVerificationComplete || isLoading}>
                 {isLoading ? '찾는 중...' : '별칭 찾기'}
               </Button>


### PR DESCRIPTION
## Summary
- ResetPasswordForm / SigninForm / SignupForm / FindNicknamePage 하단 "다음" 버튼 컨테이너의 margin-bottom을 mb-8에서 mb-2로 축소
- 화면 하단 여백이 과도하게 넓어 보이던 문제 개선

## Test plan
- [ ] 각 화면(비밀번호 재설정, 로그인, 회원가입, 별칭 찾기)에서 버튼 위치 확인
- [ ] 키보드 표시 시 버튼이 가려지지 않는지 확인
